### PR TITLE
Add MessageContent interfaces and initial implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
         <version>${netty41.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty41.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
         <version>${hubspot.immutables.version}</version>
@@ -85,6 +90,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-smtp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -21,6 +21,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.smtp.SmtpRequestEncoder;
 import io.netty.handler.codec.smtp.SmtpResponse;
 import io.netty.handler.codec.smtp.SmtpResponseDecoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
 public class SmtpSessionFactory implements Closeable  {
@@ -113,6 +114,7 @@ public class SmtpSessionFactory implements Closeable  {
       socketChannel.pipeline().addLast(
           new SmtpRequestEncoder(),
           new SmtpResponseDecoder(MAX_LINE_LENGTH),
+          new ChunkedWriteHandler(),
           responseHandler);
     }
   }

--- a/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
@@ -1,0 +1,25 @@
+package com.hubspot.smtp.messages;
+
+import com.hubspot.smtp.utils.ByteBufs;
+
+import io.netty.buffer.ByteBuf;
+
+public class ByteBufMessageContent extends MessageContent {
+  private final ByteBuf buffer;
+  private final int size;
+
+  public ByteBufMessageContent(ByteBuf buffer, boolean applyDotStuffing) {
+    this.buffer = applyDotStuffing ? ByteBufs.createDotStuffedBuffer(buffer.alloc(), buffer, null, true) : buffer;
+    size = this.buffer.readableBytes();
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public Object get8BitMimeEncodedContent() {
+    return buffer;
+  }
+}

--- a/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
@@ -1,22 +1,41 @@
 package com.hubspot.smtp.messages;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class ByteBufMessageContent extends MessageContent {
+  private static final byte CR = '\r';
+  private static final byte LF = '\n';
+  private static final byte[] CR_LF = {CR, LF};
+  private static final ByteBuf CR_LF_BUFFER = Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(CR_LF));
+
   private final ByteBuf buffer;
   private final int size;
 
   public ByteBufMessageContent(ByteBuf buffer, MessageContentEncoding encoding) {
-    this.buffer = encoding == MessageContentEncoding.REQUIRES_DOT_STUFFING ? wrap(buffer) : buffer;
+    if (encoding == MessageContentEncoding.REQUIRES_DOT_STUFFING) {
+      this.buffer = dotStuff(buffer);
+    } else {
+      this.buffer = isTerminated(buffer) ? buffer : terminate(buffer);
+    }
+
     this.size = this.buffer.readableBytes();
   }
 
-  private ByteBuf wrap(ByteBuf buffer) {
-    int length = buffer.readableBytes();
-    boolean isTerminated = length >= 2 && buffer.getByte(length - 2) == '\r' && buffer.getByte(length - 1) == '\n';
+  private static ByteBuf terminate(ByteBuf buffer) {
+    return buffer.alloc()
+        .compositeBuffer(2)
+        .addComponents(true, buffer, CR_LF_BUFFER.slice());
+  }
 
+  private static ByteBuf dotStuff(ByteBuf buffer) {
     return DotStuffing.createDotStuffedBuffer(buffer.alloc(), buffer, null,
-        isTerminated ? MessageTermination.DO_NOT_TERMINATE : MessageTermination.ADD_CRLF);
+        isTerminated(buffer) ? MessageTermination.DO_NOT_TERMINATE : MessageTermination.ADD_CRLF);
+  }
+
+  private static boolean isTerminated(ByteBuf buffer) {
+    int length = buffer.readableBytes();
+    return length >= 2 && buffer.getByte(length - 2) == '\r' && buffer.getByte(length - 1) == '\n';
   }
 
   @Override

--- a/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
@@ -8,8 +8,9 @@ public class ByteBufMessageContent extends MessageContent {
   private final ByteBuf buffer;
   private final int size;
 
-  public ByteBufMessageContent(ByteBuf buffer, boolean applyDotStuffing) {
-    this.buffer = applyDotStuffing ? ByteBufs.createDotStuffedBuffer(buffer.alloc(), buffer, null, true) : buffer;
+  public ByteBufMessageContent(ByteBuf buffer, MessageContentEncoding encoding) {
+    this.buffer = encoding == MessageContentEncoding.REQUIRES_DOT_STUFFING ?
+        ByteBufs.createDotStuffedBuffer(buffer.alloc(), buffer, null, true) : buffer;
     size = this.buffer.readableBytes();
   }
 

--- a/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/ByteBufMessageContent.java
@@ -10,7 +10,7 @@ public class ByteBufMessageContent extends MessageContent {
 
   public ByteBufMessageContent(ByteBuf buffer, MessageContentEncoding encoding) {
     this.buffer = encoding == MessageContentEncoding.REQUIRES_DOT_STUFFING ?
-        ByteBufs.createDotStuffedBuffer(buffer.alloc(), buffer, null, true) : buffer;
+        ByteBufs.createDotStuffedBuffer(buffer.alloc(), buffer, null, MessageTermination.ADD_CRLF_IF_NECESSARY) : buffer;
     size = this.buffer.readableBytes();
   }
 

--- a/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
@@ -1,0 +1,60 @@
+package com.hubspot.smtp.messages;
+
+import java.io.InputStream;
+
+import com.hubspot.smtp.utils.ByteBufs;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.stream.ChunkedStream;
+
+class DotStuffingChunkedStream extends ChunkedStream {
+  private static final byte CR = '\r';
+  private static final byte LF = '\n';
+  private static final int DEFAULT_CHUNK_SIZE = 8192;
+
+  private final int size;
+  private final byte[] trailingBytes = { CR, LF };
+  private int bytesRead = 0;
+
+  DotStuffingChunkedStream(InputStream in, int size) {
+    this(in, size, DEFAULT_CHUNK_SIZE);
+  }
+
+  DotStuffingChunkedStream(InputStream in, int size, int chunkSize) {
+    super(in, chunkSize);
+    this.size = size;
+  }
+
+  @Override
+  public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
+    ByteBuf chunk = super.readChunk(allocator);
+    bytesRead += chunk.readableBytes();
+
+    byte[] prevChunkTrailingBytes = new byte[2];
+    prevChunkTrailingBytes[0] = trailingBytes[0];
+    prevChunkTrailingBytes[1] = trailingBytes[1];
+
+    updateTrailingBytes(chunk);
+
+    boolean isLastChunk = bytesRead >= size;
+    boolean appendCRLF = isLastChunk && !(trailingBytes[0] == CR && trailingBytes[1] == LF);
+
+    return ByteBufs.createDotStuffedBuffer(allocator, chunk, prevChunkTrailingBytes, appendCRLF);
+  }
+
+  private void updateTrailingBytes(ByteBuf chunk) {
+    if (chunk.readableBytes() == 0) {
+      return;
+    }
+
+    if (chunk.readableBytes() == 1) {
+      trailingBytes[0] = trailingBytes[1];
+      trailingBytes[1] = chunk.getByte(0);
+      return;
+    }
+
+    trailingBytes[0] = chunk.getByte(chunk.readableBytes() - 2);
+    trailingBytes[1] = chunk.getByte(chunk.readableBytes() - 1);
+  }
+}

--- a/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
@@ -40,7 +40,8 @@ class DotStuffingChunkedStream extends ChunkedStream {
     boolean isLastChunk = bytesRead >= size;
     boolean appendCRLF = isLastChunk && !(trailingBytes[0] == CR && trailingBytes[1] == LF);
 
-    return ByteBufs.createDotStuffedBuffer(allocator, chunk, prevChunkTrailingBytes, appendCRLF);
+    return ByteBufs.createDotStuffedBuffer(allocator, chunk, prevChunkTrailingBytes,
+        appendCRLF ? MessageTermination.ADD_CRLF_IF_NECESSARY : MessageTermination.DO_NOT_TERMINATE);
   }
 
   private void updateTrailingBytes(ByteBuf chunk) {

--- a/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
@@ -2,8 +2,6 @@ package com.hubspot.smtp.messages;
 
 import java.io.InputStream;
 
-import com.hubspot.smtp.utils.ByteBufs;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.stream.ChunkedStream;
@@ -40,8 +38,8 @@ class DotStuffingChunkedStream extends ChunkedStream {
     boolean isLastChunk = bytesRead >= size;
     boolean appendCRLF = isLastChunk && !(trailingBytes[0] == CR && trailingBytes[1] == LF);
 
-    return ByteBufs.createDotStuffedBuffer(allocator, chunk, prevChunkTrailingBytes,
-        appendCRLF ? MessageTermination.ADD_CRLF_IF_NECESSARY : MessageTermination.DO_NOT_TERMINATE);
+    return DotStuffing.createDotStuffedBuffer(allocator, chunk, prevChunkTrailingBytes,
+        appendCRLF ? MessageTermination.ADD_CRLF : MessageTermination.DO_NOT_TERMINATE);
   }
 
   private void updateTrailingBytes(ByteBuf chunk) {

--- a/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
@@ -1,0 +1,27 @@
+package com.hubspot.smtp.messages;
+
+import java.io.InputStream;
+
+import io.netty.handler.stream.ChunkedStream;
+
+public class InputStreamMessageContent extends MessageContent {
+  private final ChunkedStream chunkedStream;
+  private final int size;
+
+  public InputStreamMessageContent(InputStream stream, int size, boolean applyDotStuffing) {
+    // note size is hard to predict if applyDotStuffing is true - the transformation might add
+    // a few extra bytes
+    this.size = size;
+    this.chunkedStream = applyDotStuffing ? new DotStuffingChunkedStream(stream, size) : new ChunkedStream(stream);
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public Object get8BitMimeEncodedContent() {
+    return chunkedStream;
+  }
+}

--- a/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
@@ -1,6 +1,10 @@
 package com.hubspot.smtp.messages;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.Supplier;
+
+import com.google.common.io.ByteSource;
 
 import io.netty.handler.stream.ChunkedStream;
 
@@ -8,11 +12,29 @@ public class InputStreamMessageContent extends MessageContent {
   private final ChunkedStream chunkedStream;
   private final int size;
 
-  public InputStreamMessageContent(InputStream stream, int size, boolean applyDotStuffing) {
+  public InputStreamMessageContent(Supplier<InputStream> stream, int size, boolean applyDotStuffing) {
+    this(stream.get(), size, applyDotStuffing);
+  }
+
+  public InputStreamMessageContent(ByteSource byteSource, int size, boolean applyDotStuffing) {
+    this(getStream(byteSource), size, applyDotStuffing);
+  }
+
+  private InputStreamMessageContent(InputStream stream, int size, boolean applyDotStuffing) {
     // note size is hard to predict if applyDotStuffing is true - the transformation might add
     // a few extra bytes
     this.size = size;
     this.chunkedStream = applyDotStuffing ? new DotStuffingChunkedStream(stream, size) : new ChunkedStream(stream);
+  }
+
+  private static Supplier<InputStream> getStream(ByteSource byteSource) {
+    return () -> {
+      try {
+        return byteSource.openStream();
+      } catch (IOException e) {
+        throw new RuntimeException("Could not open stream", e);
+      }
+    };
   }
 
   @Override

--- a/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
@@ -12,19 +12,20 @@ public class InputStreamMessageContent extends MessageContent {
   private final ChunkedStream chunkedStream;
   private final int size;
 
-  public InputStreamMessageContent(Supplier<InputStream> stream, int size, boolean applyDotStuffing) {
-    this(stream.get(), size, applyDotStuffing);
+  public InputStreamMessageContent(Supplier<InputStream> stream, int size, MessageContentEncoding encoding) {
+    this(stream.get(), size, encoding);
   }
 
-  public InputStreamMessageContent(ByteSource byteSource, int size, boolean applyDotStuffing) {
-    this(getStream(byteSource), size, applyDotStuffing);
+  public InputStreamMessageContent(ByteSource byteSource, int size, MessageContentEncoding encoding) {
+    this(getStream(byteSource), size, encoding);
   }
 
-  private InputStreamMessageContent(InputStream stream, int size, boolean applyDotStuffing) {
+  private InputStreamMessageContent(InputStream stream, int size, MessageContentEncoding encoding) {
     // note size is hard to predict if applyDotStuffing is true - the transformation might add
     // a few extra bytes
     this.size = size;
-    this.chunkedStream = applyDotStuffing ? new DotStuffingChunkedStream(stream, size) : new ChunkedStream(stream);
+    this.chunkedStream = encoding == MessageContentEncoding.REQUIRES_DOT_STUFFING ?
+        new DotStuffingChunkedStream(stream, size) : new ChunkedStream(stream);
   }
 
   private static Supplier<InputStream> getStream(ByteSource byteSource) {

--- a/src/main/java/com/hubspot/smtp/messages/MessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContent.java
@@ -1,0 +1,27 @@
+package com.hubspot.smtp.messages;
+
+import java.io.InputStream;
+
+import io.netty.buffer.ByteBuf;
+
+public abstract class MessageContent {
+  public static MessageContent of(ByteBuf messageBuffer) {
+    return new ByteBufMessageContent(messageBuffer, true);
+  }
+
+  public static MessageContent of(InputStream messageStream, int size, boolean applyDotStuffing) {
+    return new InputStreamMessageContent(messageStream, size, applyDotStuffing);
+  }
+
+  public abstract int size();
+
+  // only allow subclasses from this package because only certain objects can be returned from
+  // get8BitMimeEncodedContent / get7BitEncodedContent
+  MessageContent() {}
+
+  public abstract Object get8BitMimeEncodedContent();
+
+  public Object get7BitEncodedContent() {
+    return get8BitMimeEncodedContent();
+  }
+}

--- a/src/main/java/com/hubspot/smtp/messages/MessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContent.java
@@ -9,15 +9,15 @@ import io.netty.buffer.ByteBuf;
 
 public abstract class MessageContent {
   public static MessageContent of(ByteBuf messageBuffer) {
-    return new ByteBufMessageContent(messageBuffer, true);
+    return new ByteBufMessageContent(messageBuffer, MessageContentEncoding.REQUIRES_DOT_STUFFING);
   }
 
-  public static MessageContent of(Supplier<InputStream> messageStream, int size, boolean applyDotStuffing) {
-    return new InputStreamMessageContent(messageStream, size, applyDotStuffing);
+  public static MessageContent of(Supplier<InputStream> messageStream, int size, MessageContentEncoding encoding) {
+    return new InputStreamMessageContent(messageStream, size, encoding);
   }
 
-  public static MessageContent of(ByteSource byteSource, int size, boolean applyDotStuffing) {
-    return new InputStreamMessageContent(byteSource, size, applyDotStuffing);
+  public static MessageContent of(ByteSource byteSource, int size, MessageContentEncoding encoding) {
+    return new InputStreamMessageContent(byteSource, size, encoding);
   }
 
   public abstract int size();

--- a/src/main/java/com/hubspot/smtp/messages/MessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContent.java
@@ -1,6 +1,9 @@
 package com.hubspot.smtp.messages;
 
 import java.io.InputStream;
+import java.util.function.Supplier;
+
+import com.google.common.io.ByteSource;
 
 import io.netty.buffer.ByteBuf;
 
@@ -9,8 +12,12 @@ public abstract class MessageContent {
     return new ByteBufMessageContent(messageBuffer, true);
   }
 
-  public static MessageContent of(InputStream messageStream, int size, boolean applyDotStuffing) {
+  public static MessageContent of(Supplier<InputStream> messageStream, int size, boolean applyDotStuffing) {
     return new InputStreamMessageContent(messageStream, size, applyDotStuffing);
+  }
+
+  public static MessageContent of(ByteSource byteSource, int size, boolean applyDotStuffing) {
+    return new InputStreamMessageContent(byteSource, size, applyDotStuffing);
   }
 
   public abstract int size();

--- a/src/main/java/com/hubspot/smtp/messages/MessageContentEncoding.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContentEncoding.java
@@ -1,0 +1,6 @@
+package com.hubspot.smtp.messages;
+
+public enum MessageContentEncoding {
+  ASSUME_DOT_STUFFED,
+  REQUIRES_DOT_STUFFING
+}

--- a/src/main/java/com/hubspot/smtp/messages/MessageTermination.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageTermination.java
@@ -1,0 +1,6 @@
+package com.hubspot.smtp.messages;
+
+public enum MessageTermination {
+  DO_NOT_TERMINATE,
+  ADD_CRLF_IF_NECESSARY
+}

--- a/src/main/java/com/hubspot/smtp/messages/MessageTermination.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageTermination.java
@@ -2,5 +2,5 @@ package com.hubspot.smtp.messages;
 
 public enum MessageTermination {
   DO_NOT_TERMINATE,
-  ADD_CRLF_IF_NECESSARY
+  ADD_CRLF
 }

--- a/src/main/java/com/hubspot/smtp/utils/ByteBufs.java
+++ b/src/main/java/com/hubspot/smtp/utils/ByteBufs.java
@@ -4,15 +4,112 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ByteProcessor;
 
 public final class ByteBufs {
   private static final byte CR = '\r';
   private static final byte LF = '\n';
   private static final byte DOT = '.';
   private static final byte[] DOT_DOT = {DOT, DOT};
+  private static final byte[] NOT_CR_LF = {'x', 'x'};
   private static final byte[] CR_LF = {CR, LF};
   private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+  private static final ByteBuf DOT_DOT_BUFFER = Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(DOT_DOT));
+  private static final ByteBuf CR_LF_BUFFER = Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(CR_LF));
+
+  /**
+   * Returns a {@link CompositeByteBuf} that contains the same data as {@code sourceBuffer}, but with
+   * SMTP dot-stuffing applied, and (if {@code} appendCRLF is true) a CRLF appended.
+   *
+   * <p>If dot-stuffing is not required, and {@code appendCRLF} is false, {@code sourceBuffer} is
+   * returned. In all other cases, {@code allocator} will be used to create a new {@code ByteBuf}
+   * with a {@code refCnt} of one.
+   *
+   * <p>The {@code previousBytes} parameter is used to maintain dot-stuffing across a series
+   * of buffers. Pass the last two bytes of a previous buffer here to ensure an initial dot
+   * will be escaped if necessary. Passing null indicates this is the first or only buffer
+   * for this message.
+   *
+   * @param allocator the {@code ByteBufAllocator} to use for new {@code ByteBuf}s
+   * @param sourceBuffer the source message data
+   * @param previousBytes the previous two bytes of the message, or null
+   * @param appendCRLF whether to append CRLF to the end of the returned buffer
+   */
+  public static ByteBuf createDotStuffedBuffer(ByteBufAllocator allocator, ByteBuf sourceBuffer, byte[] previousBytes, boolean appendCRLF) {
+    int dotIndex = findDotAtBeginningOfLine(sourceBuffer, 0, normalisePreviousBytes(previousBytes));
+
+    if (dotIndex == -1) {
+      if (appendCRLF) {
+        return allocator.compositeBuffer(2).addComponents(true, sourceBuffer.retainedSlice(), CR_LF_BUFFER.slice());
+      } else {
+        return sourceBuffer.retain();
+      }
+    }
+
+    // Build a CompositeByteBuf to avoid copying
+    CompositeByteBuf compositeByteBuf = allocator.compositeBuffer();
+    compositeByteBuf.addComponents(true, sourceBuffer.retainedSlice(0, dotIndex), DOT_DOT_BUFFER.slice());
+
+    int nextDotIndex;
+    while ((nextDotIndex = findDotAtBeginningOfLine(sourceBuffer, dotIndex + 1, NOT_CR_LF)) != -1) {
+      compositeByteBuf.addComponents(true, sourceBuffer.retainedSlice(dotIndex + 1, nextDotIndex - dotIndex - 1), DOT_DOT_BUFFER.slice());
+      dotIndex = nextDotIndex;
+    }
+
+    compositeByteBuf.addComponent(true, sourceBuffer.retainedSlice(dotIndex + 1, sourceBuffer.readableBytes() - dotIndex - 1));
+
+    if (appendCRLF) {
+      compositeByteBuf.addComponent(true, CR_LF_BUFFER.slice());
+    }
+
+    return compositeByteBuf;
+  }
+
+  private static byte[] normalisePreviousBytes(byte[] previousBytes) {
+    if (previousBytes == null || previousBytes.length == 0) {
+      return CR_LF;
+    }
+    if (previousBytes.length == 1) {
+      return new byte[] { 'x', previousBytes[0] };
+    }
+    if (previousBytes.length > 2) {
+      return new byte[] { previousBytes[previousBytes.length - 2], previousBytes[previousBytes.length - 1] };
+    }
+    return previousBytes;
+  }
+
+  private static int findDotAtBeginningOfLine(ByteBuf buffer, int startAt, byte[] previousBytes) {
+    int length = buffer.readableBytes();
+
+    if (previousBytes[0] == CR && previousBytes[1] == LF && buffer.getByte(startAt) == DOT) {
+      return startAt;
+    }
+
+    if (previousBytes[1] == CR && length >= 2 && buffer.getByte(startAt) == LF && buffer.getByte(startAt + 1) == DOT) {
+      return startAt + 1;
+    }
+
+    int i = startAt;
+    while (++i < length) {
+      i = buffer.forEachByte(i, length - i, ByteProcessor.FIND_LF);
+      if (i == -1) {
+        return -1;
+      }
+
+      if (buffer.getByte(i - 1) == CR) {
+        if (i + 1 < length && buffer.getByte(i + 1) == DOT) {
+          return i + 1;
+        } else {
+          break;
+        }
+      }
+    }
+
+    return -1;
+  }
 
   public static ByteBuf createDotStuffedBuffer(byte[] bytes) {
     int dotIndex = findDotAtBeginningOfLine(bytes, 0);
@@ -40,18 +137,6 @@ public final class ByteBufs {
     return Unpooled.wrappedBuffer(buffers.toArray(new ByteBuf[buffers.size()]));
   }
 
-  // SmtpRequestEncoder will add .CRLF but we need to ensure
-  // our messages end with CRLF
-  private static byte[] getTerminatingBytes(byte[] bytes) {
-    int length = bytes.length;
-
-    if (length >= 2 && bytes[length - 2] == CR && bytes[length - 1] == LF) {
-      return EMPTY_BYTE_ARRAY;
-    } else {
-      return CR_LF;
-    }
-  }
-
   private static int findDotAtBeginningOfLine(byte[] bytes, int startAt) {
     for (int i = startAt; i < bytes.length; i++) {
       if (bytes[i] == DOT) {
@@ -67,5 +152,17 @@ public final class ByteBufs {
     }
 
     return -1;
+  }
+
+  // SmtpRequestEncoder will add .CRLF but we need to ensure
+  // our messages end with CRLF
+  private static byte[] getTerminatingBytes(byte[] bytes) {
+    int length = bytes.length;
+
+    if (length >= 2 && bytes[length - 2] == CR && bytes[length - 1] == LF) {
+      return EMPTY_BYTE_ARRAY;
+    } else {
+      return CR_LF;
+    }
   }
 }

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
@@ -1,6 +1,6 @@
 package com.hubspot.smtp.messages;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -32,18 +32,18 @@ public class DotStuffingChunkedStreamTest {
 
   private void assertDotStuffingWithChunkSize(int chunkSize) throws Exception {
     // adds
-    assertEquals(".." + CRLF, dotStuff(".", chunkSize));
-    assertEquals("..abc" + CRLF, dotStuff(".abc", chunkSize));
-    assertEquals("\r\n..def" + CRLF, dotStuff("\r\n.def", chunkSize));
-    assertEquals("abc\r\n..def" + CRLF, dotStuff("abc\r\n.def", chunkSize));
-    assertEquals("abc\r\n.." + CRLF, dotStuff("abc\r\n.", chunkSize));
-    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuff("abc\r\n.def\r\n.ghi\r\n.", chunkSize));
+    assertThat(dotStuff(".", chunkSize)).isEqualTo(".." + CRLF);
+    assertThat(dotStuff(".abc", chunkSize)).isEqualTo("..abc" + CRLF);
+    assertThat(dotStuff("\r\n.def", chunkSize)).isEqualTo("\r\n..def" + CRLF);
+    assertThat(dotStuff("abc\r\n.def", chunkSize)).isEqualTo("abc\r\n..def" + CRLF);
+    assertThat(dotStuff("abc\r\n.", chunkSize)).isEqualTo("abc\r\n.." + CRLF);
+    assertThat(dotStuff("abc\r\n.def\r\n.ghi\r\n.", chunkSize)).isEqualTo("abc\r\n..def\r\n..ghi\r\n.." + CRLF);
 
     // does not add
-    assertEquals("abc\r\ndef." + CRLF, dotStuff("abc\r\ndef.", chunkSize));
-    assertEquals("abc\r\nd.ef" + CRLF, dotStuff("abc\r\nd.ef", chunkSize));
-    assertEquals("abc\n.def" + CRLF, dotStuff("abc\n.def", chunkSize));
-    assertEquals("abc\r.def" + CRLF, dotStuff("abc\r.def", chunkSize));
+    assertThat(dotStuff("abc\r\ndef.", chunkSize)).isEqualTo("abc\r\ndef." + CRLF);
+    assertThat(dotStuff("abc\r\nd.ef", chunkSize)).isEqualTo("abc\r\nd.ef" + CRLF);
+    assertThat(dotStuff("abc\n.def", chunkSize)).isEqualTo("abc\n.def" + CRLF);
+    assertThat(dotStuff("abc\r.def", chunkSize)).isEqualTo("abc\r.def" + CRLF);
   }
 
   private String dotStuff(String testString, int chunkSize) throws Exception {

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
@@ -1,0 +1,62 @@
+package com.hubspot.smtp.messages;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.CharsetUtil;
+
+public class DotStuffingChunkedStreamTest {
+  private static final String CRLF = "\r\n";
+  private static final UnpooledByteBufAllocator ALLOCATOR = new UnpooledByteBufAllocator(true);
+  private static final int SANE_CHUNK_SIZE = 8192;
+
+  @Test
+  public void itDotStuffsAndAppendsCRLFWhenNecessary() throws Exception {
+    assertDotStuffingWithChunkSize(SANE_CHUNK_SIZE);
+  }
+
+  @Test
+  public void itDotStuffsAndAppendsCRLFWhenNecessaryWithASmallBlockSize() throws Exception {
+    // while these are terrible chunk sizes, they effectively test
+    // how we handle new lines at chunk boundaries
+    for (int chunkSize = 1; chunkSize < 10; chunkSize++) {
+      assertDotStuffingWithChunkSize(chunkSize);
+    }
+  }
+
+  private void assertDotStuffingWithChunkSize(int chunkSize) throws Exception {
+    // adds
+    assertEquals(".." + CRLF, dotStuff(".", chunkSize));
+    assertEquals("..abc" + CRLF, dotStuff(".abc", chunkSize));
+    assertEquals("\r\n..def" + CRLF, dotStuff("\r\n.def", chunkSize));
+    assertEquals("abc\r\n..def" + CRLF, dotStuff("abc\r\n.def", chunkSize));
+    assertEquals("abc\r\n.." + CRLF, dotStuff("abc\r\n.", chunkSize));
+    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuff("abc\r\n.def\r\n.ghi\r\n.", chunkSize));
+
+    // does not add
+    assertEquals("abc\r\ndef." + CRLF, dotStuff("abc\r\ndef.", chunkSize));
+    assertEquals("abc\r\nd.ef" + CRLF, dotStuff("abc\r\nd.ef", chunkSize));
+    assertEquals("abc\n.def" + CRLF, dotStuff("abc\n.def", chunkSize));
+    assertEquals("abc\r.def" + CRLF, dotStuff("abc\r.def", chunkSize));
+  }
+
+  private String dotStuff(String testString, int chunkSize) throws Exception {
+    ByteArrayInputStream stream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8));
+    DotStuffingChunkedStream chunkedStream = new DotStuffingChunkedStream(stream, testString.length(), chunkSize);
+
+    CompositeByteBuf destBuffer = ALLOCATOR.compositeBuffer();
+    while (!chunkedStream.isEndOfInput()) {
+      destBuffer.addComponent(true, chunkedStream.readChunk(ALLOCATOR).retain());
+    }
+
+    byte[] bytes = new byte[destBuffer.readableBytes()];
+    destBuffer.getBytes(0, bytes);
+    return new String(bytes, CharsetUtil.UTF_8);
+  }
+}

--- a/src/test/java/com/hubspot/smtp/utils/ByteBufsTest.java
+++ b/src/test/java/com/hubspot/smtp/utils/ByteBufsTest.java
@@ -1,7 +1,6 @@
 package com.hubspot.smtp.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
@@ -19,63 +18,63 @@ public class ByteBufsTest {
 
   @Test
   public void itEnsuresBuffersAreTerminatedWithCRLFWithByteArrays() {
-    assertEquals(CRLF, dotStuffUsingByteArray(""));
-    assertEquals("abc" + CRLF, dotStuffUsingByteArray("abc"));
-    assertEquals("abc\r" + CRLF, dotStuffUsingByteArray("abc\r"));
-    assertEquals("abc\n" + CRLF, dotStuffUsingByteArray("abc\n"));
+    assertThat(dotStuffUsingByteArray("")).isEqualTo(CRLF);
+    assertThat(dotStuffUsingByteArray("abc")).isEqualTo("abc" + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\r")).isEqualTo("abc\r" + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\n")).isEqualTo("abc\n" + CRLF);
 
-    assertEquals("abc\r\n", dotStuffUsingByteArray("abc\r\n"));
+    assertThat(dotStuffUsingByteArray("abc\r\n")).isEqualTo("abc\r\n");
   }
 
   @Test
   public void itUsesDotStuffingWithByteArrays() {
     // adds
-    assertEquals(".." + CRLF, dotStuffUsingByteArray("."));
-    assertEquals("..abc" + CRLF, dotStuffUsingByteArray(".abc"));
-    assertEquals("\r\n..def" + CRLF, dotStuffUsingByteArray("\r\n.def"));
-    assertEquals("abc\r\n..def" + CRLF, dotStuffUsingByteArray("abc\r\n.def"));
-    assertEquals("abc\r\n.." + CRLF, dotStuffUsingByteArray("abc\r\n."));
-    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuffUsingByteArray("abc\r\n.def\r\n.ghi\r\n."));
+    assertThat(dotStuffUsingByteArray(".")).isEqualTo(".." + CRLF);
+    assertThat(dotStuffUsingByteArray(".abc")).isEqualTo("..abc" + CRLF);
+    assertThat(dotStuffUsingByteArray("\r\n.def")).isEqualTo("\r\n..def" + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\r\n.def")).isEqualTo("abc\r\n..def" + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\r\n.")).isEqualTo("abc\r\n.." + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\r\n.def\r\n.ghi\r\n.")).isEqualTo("abc\r\n..def\r\n..ghi\r\n.." + CRLF);
 
     // does not add
-    assertEquals("abc\r\ndef." + CRLF, dotStuffUsingByteArray("abc\r\ndef."));
-    assertEquals("abc\r\nd.ef" + CRLF, dotStuffUsingByteArray("abc\r\nd.ef"));
-    assertEquals("abc\n.def" + CRLF, dotStuffUsingByteArray("abc\n.def"));
-    assertEquals("abc\r.def" + CRLF, dotStuffUsingByteArray("abc\r.def"));
+    assertThat(dotStuffUsingByteArray("abc\r\ndef.")).isEqualTo("abc\r\ndef." + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\r\nd.ef")).isEqualTo("abc\r\nd.ef" + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\n.def")).isEqualTo("abc\n.def" + CRLF);
+    assertThat(dotStuffUsingByteArray("abc\r.def")).isEqualTo("abc\r.def" + CRLF);
   }
 
   @Test
   public void itEnsuresBuffersAreTerminatedWithCRLFWithByteBufs() {
-    assertEquals(CRLF, dotStuffUsingByteBuf(""));
-    assertEquals("abc" + CRLF, dotStuffUsingByteBuf("abc"));
-    assertEquals("abc\r" + CRLF, dotStuffUsingByteBuf("abc\r"));
-    assertEquals("abc\n" + CRLF, dotStuffUsingByteBuf("abc\n"));
+    assertThat(dotStuffUsingByteBuf("")).isEqualTo(CRLF);
+    assertThat(dotStuffUsingByteBuf("abc")).isEqualTo("abc" + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r")).isEqualTo("abc\r" + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\n")).isEqualTo("abc\n" + CRLF);
   }
 
   @Test
   public void itUsesDotStuffingWithByteBufs() {
     // adds
-    assertEquals("" + CRLF, dotStuffUsingByteBuf(""));
-    assertEquals(".." + CRLF, dotStuffUsingByteBuf("."));
-    assertEquals("..abc" + CRLF, dotStuffUsingByteBuf(".abc"));
-    assertEquals("\r\n..def" + CRLF, dotStuffUsingByteBuf("\r\n.def"));
-    assertEquals("abc\r\n..def" + CRLF, dotStuffUsingByteBuf("abc\r\n.def"));
-    assertEquals("abc\r\n.." + CRLF, dotStuffUsingByteBuf("abc\r\n."));
-    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuffUsingByteBuf("abc\r\n.def\r\n.ghi\r\n."));
+    assertThat(dotStuffUsingByteBuf("")).isEqualTo("" + CRLF);
+    assertThat(dotStuffUsingByteBuf(".")).isEqualTo(".." + CRLF);
+    assertThat(dotStuffUsingByteBuf(".abc")).isEqualTo("..abc" + CRLF);
+    assertThat(dotStuffUsingByteBuf("\r\n.def")).isEqualTo("\r\n..def" + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r\n.def")).isEqualTo("abc\r\n..def" + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r\n.")).isEqualTo("abc\r\n.." + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r\n.def\r\n.ghi\r\n.")).isEqualTo("abc\r\n..def\r\n..ghi\r\n.." + CRLF);
 
     // does not add
-    assertEquals("abc\r\ndef." + CRLF, dotStuffUsingByteBuf("abc\r\ndef."));
-    assertEquals("abc\r\nd.ef" + CRLF, dotStuffUsingByteBuf("abc\r\nd.ef"));
-    assertEquals("abc\n.def" + CRLF, dotStuffUsingByteBuf("abc\n.def"));
-    assertEquals("abc\r.def" + CRLF, dotStuffUsingByteBuf("abc\r.def"));
+    assertThat(dotStuffUsingByteBuf("abc\r\ndef.")).isEqualTo("abc\r\ndef." + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r\nd.ef")).isEqualTo("abc\r\nd.ef" + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\n.def")).isEqualTo("abc\n.def" + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r.def")).isEqualTo("abc\r.def" + CRLF);
 
     // atStartOfLine
-    assertEquals("..\r\n..", dotStuffUsingByteBuf(".\r\n.", true, false));
-    assertEquals(".\r\n..", dotStuffUsingByteBuf(".\r\n.", false, false));
+    assertThat(dotStuffUsingByteBuf(".\r\n.", true, false)).isEqualTo("..\r\n..");
+    assertThat(dotStuffUsingByteBuf(".\r\n.", false, false)).isEqualTo(".\r\n..");
 
     // appendCRLF
-    assertEquals("x\r\n", dotStuffUsingByteBuf("x", true, true));
-    assertEquals("x", dotStuffUsingByteBuf("x", true, false));
+    assertThat(dotStuffUsingByteBuf("x", true, true)).isEqualTo("x\r\n");
+    assertThat(dotStuffUsingByteBuf("x", true, false)).isEqualTo("x");
   }
 
   @Test

--- a/src/test/java/com/hubspot/smtp/utils/ByteBufsTest.java
+++ b/src/test/java/com/hubspot/smtp/utils/ByteBufsTest.java
@@ -1,5 +1,6 @@
 package com.hubspot.smtp.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
@@ -7,43 +8,128 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.CharsetUtil;
 
 public class ByteBufsTest {
   private static final String CRLF = "\r\n";
+  private static final UnpooledByteBufAllocator ALLOCATOR = new UnpooledByteBufAllocator(true);
 
   @Test
-  public void itEnsuresBuffersAreTerminatedWithCRLF() {
-    assertEquals(CRLF, dotStuff(""));
-    assertEquals("abc" + CRLF, dotStuff("abc"));
-    assertEquals("abc\r" + CRLF, dotStuff("abc\r"));
-    assertEquals("abc\n" + CRLF, dotStuff("abc\n"));
+  public void itEnsuresBuffersAreTerminatedWithCRLFWithByteArrays() {
+    assertEquals(CRLF, dotStuffUsingByteArray(""));
+    assertEquals("abc" + CRLF, dotStuffUsingByteArray("abc"));
+    assertEquals("abc\r" + CRLF, dotStuffUsingByteArray("abc\r"));
+    assertEquals("abc\n" + CRLF, dotStuffUsingByteArray("abc\n"));
 
-    assertEquals("abc\r\n", dotStuff("abc\r\n"));
+    assertEquals("abc\r\n", dotStuffUsingByteArray("abc\r\n"));
   }
 
   @Test
-  public void itUsesDotStuffing() {
+  public void itUsesDotStuffingWithByteArrays() {
     // adds
-    assertEquals(".." + CRLF, dotStuff("."));
-    assertEquals("..abc" + CRLF, dotStuff(".abc"));
-    assertEquals("\r\n..def" + CRLF, dotStuff("\r\n.def"));
-    assertEquals("abc\r\n..def" + CRLF, dotStuff("abc\r\n.def"));
-    assertEquals("abc\r\n.." + CRLF, dotStuff("abc\r\n."));
-    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuff("abc\r\n.def\r\n.ghi\r\n."));
+    assertEquals(".." + CRLF, dotStuffUsingByteArray("."));
+    assertEquals("..abc" + CRLF, dotStuffUsingByteArray(".abc"));
+    assertEquals("\r\n..def" + CRLF, dotStuffUsingByteArray("\r\n.def"));
+    assertEquals("abc\r\n..def" + CRLF, dotStuffUsingByteArray("abc\r\n.def"));
+    assertEquals("abc\r\n.." + CRLF, dotStuffUsingByteArray("abc\r\n."));
+    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuffUsingByteArray("abc\r\n.def\r\n.ghi\r\n."));
 
     // does not add
-    assertEquals("abc\r\ndef." + CRLF, dotStuff("abc\r\ndef."));
-    assertEquals("abc\r\nd.ef" + CRLF, dotStuff("abc\r\nd.ef"));
-    assertEquals("abc\n.def" + CRLF, dotStuff("abc\n.def"));
-    assertEquals("abc\r.def" + CRLF, dotStuff("abc\r.def"));
+    assertEquals("abc\r\ndef." + CRLF, dotStuffUsingByteArray("abc\r\ndef."));
+    assertEquals("abc\r\nd.ef" + CRLF, dotStuffUsingByteArray("abc\r\nd.ef"));
+    assertEquals("abc\n.def" + CRLF, dotStuffUsingByteArray("abc\n.def"));
+    assertEquals("abc\r.def" + CRLF, dotStuffUsingByteArray("abc\r.def"));
   }
 
-  private String dotStuff(String testString) {
+  @Test
+  public void itEnsuresBuffersAreTerminatedWithCRLFWithByteBufs() {
+    assertEquals(CRLF, dotStuffUsingByteBuf(""));
+    assertEquals("abc" + CRLF, dotStuffUsingByteBuf("abc"));
+    assertEquals("abc\r" + CRLF, dotStuffUsingByteBuf("abc\r"));
+    assertEquals("abc\n" + CRLF, dotStuffUsingByteBuf("abc\n"));
+  }
+
+  @Test
+  public void itUsesDotStuffingWithByteBufs() {
+    // adds
+    assertEquals("" + CRLF, dotStuffUsingByteBuf(""));
+    assertEquals(".." + CRLF, dotStuffUsingByteBuf("."));
+    assertEquals("..abc" + CRLF, dotStuffUsingByteBuf(".abc"));
+    assertEquals("\r\n..def" + CRLF, dotStuffUsingByteBuf("\r\n.def"));
+    assertEquals("abc\r\n..def" + CRLF, dotStuffUsingByteBuf("abc\r\n.def"));
+    assertEquals("abc\r\n.." + CRLF, dotStuffUsingByteBuf("abc\r\n."));
+    assertEquals("abc\r\n..def\r\n..ghi\r\n.." + CRLF, dotStuffUsingByteBuf("abc\r\n.def\r\n.ghi\r\n."));
+
+    // does not add
+    assertEquals("abc\r\ndef." + CRLF, dotStuffUsingByteBuf("abc\r\ndef."));
+    assertEquals("abc\r\nd.ef" + CRLF, dotStuffUsingByteBuf("abc\r\nd.ef"));
+    assertEquals("abc\n.def" + CRLF, dotStuffUsingByteBuf("abc\n.def"));
+    assertEquals("abc\r.def" + CRLF, dotStuffUsingByteBuf("abc\r.def"));
+
+    // atStartOfLine
+    assertEquals("..\r\n..", dotStuffUsingByteBuf(".\r\n.", true, false));
+    assertEquals(".\r\n..", dotStuffUsingByteBuf(".\r\n.", false, false));
+
+    // appendCRLF
+    assertEquals("x\r\n", dotStuffUsingByteBuf("x", true, true));
+    assertEquals("x", dotStuffUsingByteBuf("x", true, false));
+  }
+
+  @Test
+  public void itRetainsSourceByteBufs() {
+    String testString = "abc\r\n.def\r\n.ghi\r\n.";
+
+    ByteBuf sourceBuffer = ALLOCATOR.buffer();
+    sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
+    assertThat(sourceBuffer.refCnt()).isEqualTo(1);
+
+    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, true);
+    assertThat(destBuffer.refCnt()).isEqualTo(1);
+
+    // should be able to release both of these successfully
+    sourceBuffer.release();
+    destBuffer.release();
+  }
+
+  @Test
+  public void itRetainsTheSourceByteIfNoProcessingIsRequired() {
+    String testString = "abc";
+
+    ByteBuf sourceBuffer = ALLOCATOR.buffer();
+    sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
+    assertThat(sourceBuffer.refCnt()).isEqualTo(1);
+
+    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, false);
+    assertThat(destBuffer).isSameAs(sourceBuffer);
+    assertThat(sourceBuffer.refCnt()).isEqualTo(2);
+
+    // should be able to release both of these successfully
+    sourceBuffer.release();
+    destBuffer.release();
+  }
+
+  private String dotStuffUsingByteArray(String testString) {
     ByteBuf buffer = ByteBufs.createDotStuffedBuffer(testString.getBytes(StandardCharsets.UTF_8));
 
-    byte[] bytes = new byte[buffer.capacity()];
+    byte[] bytes = new byte[buffer.readableBytes()];
     buffer.getBytes(0, bytes);
+    return new String(bytes, CharsetUtil.UTF_8);
+  }
+
+  private String dotStuffUsingByteBuf(String testString) {
+    return dotStuffUsingByteBuf(testString, true, true);
+  }
+
+  private String dotStuffUsingByteBuf(String testString, boolean atStartOfLine, boolean appendCRLF) {
+    ByteBuf sourceBuffer = ALLOCATOR.buffer();
+    sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
+
+    byte[] previousBytes = atStartOfLine ? null : new byte[] { 'x', 'y' };
+    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, previousBytes, appendCRLF);
+
+    byte[] bytes = new byte[destBuffer.readableBytes()];
+    destBuffer.getBytes(0, bytes);
     return new String(bytes, CharsetUtil.UTF_8);
   }
 }

--- a/src/test/java/com/hubspot/smtp/utils/ByteBufsTest.java
+++ b/src/test/java/com/hubspot/smtp/utils/ByteBufsTest.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
+import com.hubspot.smtp.messages.MessageTermination;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.CharsetUtil;
@@ -84,7 +86,7 @@ public class ByteBufsTest {
     sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
     assertThat(sourceBuffer.refCnt()).isEqualTo(1);
 
-    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, true);
+    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, MessageTermination.ADD_CRLF_IF_NECESSARY);
     assertThat(destBuffer.refCnt()).isEqualTo(1);
 
     // should be able to release both of these successfully
@@ -100,7 +102,7 @@ public class ByteBufsTest {
     sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
     assertThat(sourceBuffer.refCnt()).isEqualTo(1);
 
-    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, false);
+    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, MessageTermination.DO_NOT_TERMINATE);
     assertThat(destBuffer).isSameAs(sourceBuffer);
     assertThat(sourceBuffer.refCnt()).isEqualTo(2);
 
@@ -126,7 +128,8 @@ public class ByteBufsTest {
     sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
 
     byte[] previousBytes = atStartOfLine ? null : new byte[] { 'x', 'y' };
-    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, previousBytes, appendCRLF);
+    ByteBuf destBuffer = ByteBufs.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, previousBytes,
+        appendCRLF ? MessageTermination.ADD_CRLF_IF_NECESSARY : MessageTermination.DO_NOT_TERMINATE);
 
     byte[] bytes = new byte[destBuffer.readableBytes()];
     destBuffer.getBytes(0, bytes);


### PR DESCRIPTION
Adds an abstract class, `MessageContent` together with two concrete subclasses, `ByteBufMessageContent` and `InputStreamMessageContent` to encapsulate the data of a message.

Both subclasses support dot-stuffing and can ensure the message content ends with `CRLF` so the SMTP connection doesn't hang. `InputStreamMessageContent` uses chunking to ensure large messages are sent without consuming too much memory, and tracks newlines across chunks to perform dot-stuffing.

@axiak 