### PR TITLE
Timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
 
+script: mvn -B -q clean install
+
 cache:
   directories:
   - $HOME/.m2

--- a/src/main/java/com/hubspot/smtp/TestApp.java
+++ b/src/main/java/com/hubspot/smtp/TestApp.java
@@ -8,7 +8,6 @@ import static io.netty.handler.codec.smtp.SmtpCommand.RCPT;
 import static io.netty.handler.codec.smtp.SmtpCommand.RSET;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.List;
@@ -56,7 +55,7 @@ class TestApp {
     ByteBuf messageBuffer = Unpooled.wrappedBuffer(TEST_EMAIL.getBytes(StandardCharsets.UTF_8));
     Supplier<MessageContent> contentProvider = () -> MessageContent.of(messageBuffer);
 
-    SmtpSessionConfig config = SmtpSessionConfig.forRemoteAddress(InetSocketAddress.createUnresolved("localhost", 9925));
+    SmtpSessionConfig config = SmtpSessionConfig.forRemoteAddress("localhost", 9925);
 
     CompletableFuture<SmtpClientResponse[]> future = new SmtpSessionFactory(EVENT_LOOP_GROUP, EXECUTOR_SERVICE).connect(config)
         .thenCompose(r -> r.getSession().send(req(EHLO, "hubspot.com")))
@@ -79,7 +78,7 @@ class TestApp {
   private static void sendEmail(NioEventLoopGroup eventLoopGroup) throws InterruptedException, ExecutionException {
     SmtpClient client = new SmtpClient(eventLoopGroup, new SmtpSessionFactory(EVENT_LOOP_GROUP, EXECUTOR_SERVICE));
 
-    client.connect(SmtpSessionConfig.forRemoteAddress(InetSocketAddress.createUnresolved("localhost", 9925)))
+    client.connect(SmtpSessionConfig.forRemoteAddress("localhost", 9925))
         .thenCompose(r -> client.ehlo(r.getSession(), "hubspot.com"))
         .thenCompose(r -> client.mail(r.getSession(), "mobrien@hubspot.com"))
         .thenCompose(r -> client.rcpt(r.getSession(), "michael@mcobrien.org"))

--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -1,0 +1,30 @@
+package com.hubspot.smtp.client;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.smtp.SmtpRequestEncoder;
+import io.netty.handler.codec.smtp.SmtpResponseDecoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+class Initializer extends ChannelInitializer<SocketChannel> {
+  private static final int MAX_LINE_LENGTH = 200;
+
+  private final ResponseHandler responseHandler;
+  private final SmtpSessionConfig config;
+
+  Initializer(ResponseHandler responseHandler, SmtpSessionConfig config) {
+    this.responseHandler = responseHandler;
+    this.config = config;
+  }
+
+  @Override
+  protected void initChannel(SocketChannel socketChannel) throws Exception {
+    socketChannel.pipeline().addLast(
+        new SmtpRequestEncoder(),
+        new SmtpResponseDecoder(MAX_LINE_LENGTH),
+        new ChunkedWriteHandler(),
+        new ReadTimeoutHandler(config.getReadTimeoutSeconds()),
+        responseHandler);
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -24,7 +24,7 @@ class Initializer extends ChannelInitializer<SocketChannel> {
         new SmtpRequestEncoder(),
         new SmtpResponseDecoder(MAX_LINE_LENGTH),
         new ChunkedWriteHandler(),
-        new ReadTimeoutHandler(config.getReadTimeoutSeconds()),
+        new ReadTimeoutHandler((int) config.getReadTimeout().getSeconds()),
         responseHandler);
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
@@ -2,45 +2,29 @@ package com.hubspot.smtp.client;
 
 import java.net.InetSocketAddress;
 
-public class SmtpSessionConfig {
-  private final InetSocketAddress remoteAddress;
-  private final InetSocketAddress localAddress;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
 
-  private int readTimeoutSeconds = 30;
-  private String connectionId = "unidentified-connection";
+@Immutable
+public abstract class SmtpSessionConfig {
+  public abstract InetSocketAddress getRemoteAddress();
+  public abstract InetSocketAddress getLocalAddress();
+
+  @Default
+  public int getReadTimeoutSeconds() {
+    return 30;
+  }
+
+  @Default
+  public String getConnectionId() {
+    return "unidentified-connection";
+  }
+
+  public static SmtpSessionConfig forRemoteAddress(String host, int port) {
+    return forRemoteAddress(InetSocketAddress.createUnresolved(host, port));
+  }
 
   public static SmtpSessionConfig forRemoteAddress(InetSocketAddress remoteAddress) {
-    return new SmtpSessionConfig(remoteAddress, null);
-  }
-
-  public SmtpSessionConfig(InetSocketAddress remoteAddress, InetSocketAddress localAddress) {
-    this.remoteAddress = remoteAddress;
-    this.localAddress = localAddress;
-  }
-
-  public InetSocketAddress getRemoteAddress() {
-    return remoteAddress;
-  }
-
-  public InetSocketAddress getLocalAddress() {
-    return localAddress;
-  }
-
-  public int getReadTimeoutSeconds() {
-    return readTimeoutSeconds;
-  }
-
-  public SmtpSessionConfig setReadTimeoutSeconds(int readTimeoutSeconds) {
-    this.readTimeoutSeconds = readTimeoutSeconds;
-    return this;
-  }
-
-  public String getConnectionId() {
-    return connectionId;
-  }
-
-  public SmtpSessionConfig setConnectionId(String connectionId) {
-    this.connectionId = connectionId;
-    return this;
+    return ImmutableSmtpSessionConfig.builder().remoteAddress(remoteAddress).build();
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
@@ -1,6 +1,8 @@
 package com.hubspot.smtp.client;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Optional;
 
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
@@ -8,11 +10,11 @@ import org.immutables.value.Value.Immutable;
 @Immutable
 public abstract class SmtpSessionConfig {
   public abstract InetSocketAddress getRemoteAddress();
-  public abstract InetSocketAddress getLocalAddress();
+  public abstract Optional<InetSocketAddress> getLocalAddress();
 
   @Default
-  public int getReadTimeoutSeconds() {
-    return 30;
+  public Duration getReadTimeout() {
+    return Duration.ofMinutes(2);
   }
 
   @Default

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
@@ -6,6 +6,9 @@ public class SmtpSessionConfig {
   private final InetSocketAddress remoteAddress;
   private final InetSocketAddress localAddress;
 
+  private int readTimeoutSeconds = 30;
+  private String connectionId = "unidentified-connection";
+
   public static SmtpSessionConfig forRemoteAddress(InetSocketAddress remoteAddress) {
     return new SmtpSessionConfig(remoteAddress, null);
   }
@@ -21,5 +24,23 @@ public class SmtpSessionConfig {
 
   public InetSocketAddress getLocalAddress() {
     return localAddress;
+  }
+
+  public int getReadTimeoutSeconds() {
+    return readTimeoutSeconds;
+  }
+
+  public SmtpSessionConfig setReadTimeoutSeconds(int readTimeoutSeconds) {
+    this.readTimeoutSeconds = readTimeoutSeconds;
+    return this;
+  }
+
+  public String getConnectionId() {
+    return connectionId;
+  }
+
+  public SmtpSessionConfig setConnectionId(String connectionId) {
+    this.connectionId = connectionId;
+    return this;
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -41,7 +41,7 @@ public class SmtpSessionFactory implements Closeable  {
         .group(eventLoopGroup)
         .channel(NioSocketChannel.class)
         .remoteAddress(config.getRemoteAddress())
-        .localAddress(config.getLocalAddress())
+        .localAddress(config.getLocalAddress().orElse(null))
         .handler(new Initializer(responseHandler, config));
 
     CompletableFuture<SmtpClientResponse> connectFuture = new CompletableFuture<>();

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -12,21 +12,15 @@ import org.slf4j.LoggerFactory;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelInitializer;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.smtp.SmtpRequestEncoder;
 import io.netty.handler.codec.smtp.SmtpResponse;
-import io.netty.handler.codec.smtp.SmtpResponseDecoder;
-import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
 public class SmtpSessionFactory implements Closeable  {
   private static final Logger LOG = LoggerFactory.getLogger(SmtpSessionFactory.class);
-  private static final int MAX_LINE_LENGTH = 200;
 
   private final NioEventLoopGroup eventLoopGroup;
   private final ExecutorService executorService;
@@ -40,7 +34,7 @@ public class SmtpSessionFactory implements Closeable  {
   }
 
   public CompletableFuture<SmtpClientResponse> connect(SmtpSessionConfig config) {
-    ResponseHandler responseHandler = new ResponseHandler();
+    ResponseHandler responseHandler = new ResponseHandler(config.getConnectionId());
     CompletableFuture<SmtpResponse[]> initialResponseFuture = responseHandler.createResponseFuture(1, () -> "initial response");
 
     Bootstrap bootstrap = new Bootstrap()
@@ -48,7 +42,7 @@ public class SmtpSessionFactory implements Closeable  {
         .channel(NioSocketChannel.class)
         .remoteAddress(config.getRemoteAddress())
         .localAddress(config.getLocalAddress())
-        .handler(new Initializer(responseHandler));
+        .handler(new Initializer(responseHandler, config));
 
     CompletableFuture<SmtpClientResponse> connectFuture = new CompletableFuture<>();
 
@@ -102,20 +96,4 @@ public class SmtpSessionFactory implements Closeable  {
     return returnedFuture;
   }
 
-  private static class Initializer extends ChannelInitializer<SocketChannel> {
-    private final ResponseHandler responseHandler;
-
-    Initializer(ResponseHandler responseHandler) {
-      this.responseHandler = responseHandler;
-    }
-
-    @Override
-    protected void initChannel(SocketChannel socketChannel) throws Exception {
-      socketChannel.pipeline().addLast(
-          new SmtpRequestEncoder(),
-          new SmtpResponseDecoder(MAX_LINE_LENGTH),
-          new ChunkedWriteHandler(),
-          responseHandler);
-    }
-  }
 }

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -18,13 +18,15 @@ import io.netty.handler.codec.smtp.SmtpResponse;
 public class ResponseHandlerTest {
   private static final DefaultSmtpResponse SMTP_RESPONSE = new DefaultSmtpResponse(250);
   private static final Supplier<String> DEBUG_STRING = () -> "debug";
+  private static final String CONNECTION_ID = "connection#1";
+  private static final String CONNECTION_ID_PREFIX = "[" + CONNECTION_ID + "] ";
 
   private ResponseHandler responseHandler;
   private ChannelHandlerContext context;
 
   @Before
   public void setup() {
-    responseHandler = new ResponseHandler();
+    responseHandler = new ResponseHandler(CONNECTION_ID);
     context = mock(ChannelHandlerContext.class);
   }
 
@@ -64,7 +66,7 @@ public class ResponseHandlerTest {
 
     assertThatThrownBy(() -> responseHandler.createResponseFuture(1, () -> "new"))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot wait for a response to [new] because we're still waiting for a response to [old]");
+        .hasMessage(CONNECTION_ID_PREFIX + "Cannot wait for a response to [new] because we're still waiting for a response to [old]");
   }
 
   @Test
@@ -73,7 +75,7 @@ public class ResponseHandlerTest {
 
     assertThatThrownBy(() -> responseHandler.createResponseFuture(1, () -> "new"))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot wait for a response to [new] because we're still waiting for a response to [old]");
+        .hasMessage(CONNECTION_ID_PREFIX + "Cannot wait for a response to [new] because we're still waiting for a response to [old]");
   }
 
   @Test


### PR DESCRIPTION
Close the connection if a read has timed out after 30 seconds, configurable with the `SmtpSessionConfig` class, which is now an [immutable](https://immutables.github.io/).

When a timeout occurs, the connection is closed by Netty's `ReadTimeoutHandler` and any pending CompletableFuture is completed exceptionally with the `ReadTimeoutException`.

This PR also adds a `connectionId` string provided in the config, which is included in log lines when timeouts occur and when unexpected responses arrive.

@axiak 