### PR TITLE
Keep connections alive with NOOP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,10 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/hubspot/smtp/client/ChannelClosedException.java
+++ b/src/main/java/com/hubspot/smtp/client/ChannelClosedException.java
@@ -1,15 +1,7 @@
 package com.hubspot.smtp.client;
 
-public class ChannelClosedException extends Exception {
+public class ChannelClosedException extends SmtpException {
   public ChannelClosedException(String connectionId, String message) {
-    super(constructErrorMessage(connectionId, message));
-  }
-
-  private static String constructErrorMessage(String connectionId, String message) {
-    if (connectionId == null || connectionId.length() == 0) {
-      return message;
-    } else {
-      return String.format("[%s] %s", connectionId, message);
-    }
+    super(connectionId, message);
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/ChannelClosedException.java
+++ b/src/main/java/com/hubspot/smtp/client/ChannelClosedException.java
@@ -1,0 +1,15 @@
+package com.hubspot.smtp.client;
+
+public class ChannelClosedException extends Exception {
+  public ChannelClosedException(String connectionId, String message) {
+    super(constructErrorMessage(connectionId, message));
+  }
+
+  private static String constructErrorMessage(String connectionId, String message) {
+    if (connectionId == null || connectionId.length() == 0) {
+      return message;
+    } else {
+      return String.format("[%s] %s", connectionId, message);
+    }
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/ErrorResponseException.java
+++ b/src/main/java/com/hubspot/smtp/client/ErrorResponseException.java
@@ -1,0 +1,7 @@
+package com.hubspot.smtp.client;
+
+public class ErrorResponseException extends SmtpException {
+  public ErrorResponseException(String connectionId, String message) {
+    super(connectionId, message);
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -8,7 +8,7 @@ import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 
 class Initializer extends ChannelInitializer<SocketChannel> {
-  private static final int MAX_LINE_LENGTH = 200;
+  private static final int MAX_LINE_LENGTH = 1000;
 
   private final ResponseHandler responseHandler;
   private final SmtpSessionConfig config;

--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -33,7 +33,7 @@ class Initializer extends ChannelInitializer<SocketChannel> {
     handlers.add(new SmtpRequestEncoder());
     handlers.add(new SmtpResponseDecoder(MAX_LINE_LENGTH));
     handlers.add(new ChunkedWriteHandler());
-    handlers.add(new ReadTimeoutHandler((int) config.getReadTimeout().getSeconds()));
+    handlers.add(new ReadTimeoutHandler(Math.toIntExact(config.getReadTimeout().getSeconds())));
 
     config.getKeepAliveTimeout().ifPresent(timeout -> handlers.add(new KeepAliveHandler(responseHandler, config.getConnectionId(), timeout)));
 

--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -25,6 +25,7 @@ class Initializer extends ChannelInitializer<SocketChannel> {
         new SmtpResponseDecoder(MAX_LINE_LENGTH),
         new ChunkedWriteHandler(),
         new ReadTimeoutHandler((int) config.getReadTimeout().getSeconds()),
+        new KeepAliveHandler(responseHandler, config.getConnectionId(), config.getKeepAliveTimeout()),
         responseHandler);
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
@@ -1,0 +1,97 @@
+package com.hubspot.smtp.client;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.hubspot.smtp.utils.SmtpResponses;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.smtp.DefaultSmtpRequest;
+import io.netty.handler.codec.smtp.SmtpCommand;
+import io.netty.handler.codec.smtp.SmtpResponse;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+
+class KeepAliveHandler extends IdleStateHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(KeepAliveHandler.class);
+
+  private final ResponseHandler responseHandler;
+  private final String connectionId;
+  private final List<PendingWrite> pendingWrites = Lists.newArrayList();
+
+  private boolean expectingNoopResponse;
+
+  KeepAliveHandler(ResponseHandler responseHandler, String connectionId, Duration idleTimeout) {
+    // just track overall idle time; disable individual reader & writer timers by passing zero
+    super(0, 0, (int) idleTimeout.getSeconds());
+
+    this.responseHandler = responseHandler;
+    this.connectionId = connectionId;
+  }
+
+  @Override
+  protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
+    LOG.debug("[{}] Sending NOOP to keep the connection alive", connectionId);
+
+    if (expectingNoopResponse) {
+      LOG.warn("[{}] Did not receive a response to our last NOOP, will not send another", connectionId);
+    } else if (responseHandler.isResponsePending()) {
+      LOG.warn("[{}] Waiting for a response, will not send a NOOP to keep the connection alive", connectionId);
+    } else {
+      ctx.channel().writeAndFlush(new DefaultSmtpRequest(SmtpCommand.NOOP));
+      expectingNoopResponse = true;
+    }
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (expectingNoopResponse && msg instanceof SmtpResponse) {
+      swallowNoopResponse((SmtpResponse) msg);
+      sendPendingWrites(ctx);
+      return;
+    }
+
+    super.channelRead(ctx, msg);
+  }
+
+  private void swallowNoopResponse(SmtpResponse msg) {
+    expectingNoopResponse = false;
+
+    if (SmtpResponses.isError(msg)) {
+      LOG.warn("[{}] Received error {} in response to NOOP", connectionId, SmtpResponses.toString(msg));
+    }
+  }
+
+  private void sendPendingWrites(ChannelHandlerContext ctx) throws Exception {
+    for (PendingWrite w : pendingWrites) {
+      write(ctx, w.msg, w.promise);
+    }
+    pendingWrites.clear();
+  }
+
+  @Override
+  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    // queue any pending writes until the response is received
+    if (expectingNoopResponse) {
+      pendingWrites.add(new PendingWrite(msg, promise));
+      return;
+    }
+
+    super.write(ctx, msg, promise);
+  }
+
+  private static class PendingWrite {
+    private Object msg;
+    private ChannelPromise promise;
+
+    PendingWrite(Object msg, ChannelPromise promise) {
+      this.msg = msg;
+      this.promise = promise;
+    }
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
@@ -59,11 +59,12 @@ class KeepAliveHandler extends IdleStateHandler {
     super.channelRead(ctx, msg);
   }
 
-  private void swallowNoopResponse(SmtpResponse msg) {
+  private void swallowNoopResponse(SmtpResponse msg) throws ErrorResponseException {
     expectingNoopResponse = false;
 
     if (SmtpResponses.isError(msg)) {
       LOG.warn("[{}] Received error {} in response to NOOP", connectionId, SmtpResponses.toString(msg));
+      throw new ErrorResponseException(connectionId, "Received " + SmtpResponses.toString(msg));
     }
   }
 

--- a/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
@@ -28,7 +28,7 @@ class KeepAliveHandler extends IdleStateHandler {
 
   KeepAliveHandler(ResponseHandler responseHandler, String connectionId, Duration idleTimeout) {
     // just track overall idle time; disable individual reader & writer timers by passing zero
-    super(0, 0, (int) idleTimeout.getSeconds());
+    super(0, 0, Math.toIntExact(idleTimeout.getSeconds()));
 
     this.responseHandler = responseHandler;
     this.connectionId = connectionId;

--- a/src/main/java/com/hubspot/smtp/client/ResponseHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/ResponseHandler.java
@@ -74,6 +74,8 @@ class ResponseHandler extends SimpleChannelInboundHandler<SmtpResponse> {
     if (collector != null) {
       collector.completeExceptionally(cause);
     }
+
+    super.exceptionCaught(ctx, cause);
   }
 
   @Override

--- a/src/main/java/com/hubspot/smtp/client/SmtpClientResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpClientResponse.java
@@ -2,13 +2,11 @@ package com.hubspot.smtp.client;
 
 import java.util.List;
 
-import com.google.common.base.Joiner;
+import com.hubspot.smtp.utils.SmtpResponses;
 
 import io.netty.handler.codec.smtp.SmtpResponse;
 
 public class SmtpClientResponse implements SmtpResponse {
-  private static final Joiner SPACE_JOINER = Joiner.on(" ");
-
   private final SmtpResponse response;
   private final SmtpSession session;
 
@@ -27,18 +25,6 @@ public class SmtpClientResponse implements SmtpResponse {
     return response.details();
   }
 
-  public boolean isTransientError() {
-    return response.code() >= 400 && response.code() < 500;
-  }
-
-  public boolean isPermanentError() {
-    return response.code() >= 500;
-  }
-
-  public boolean isError() {
-    return isTransientError() || isPermanentError();
-  }
-
   public SmtpSession getSession() {
     return session;
   }
@@ -48,7 +34,7 @@ public class SmtpClientResponse implements SmtpResponse {
     if (response == null) {
       return super.toString();
     } else {
-      return code() + " " + SPACE_JOINER.join(details());
+      return SmtpResponses.toString(response);
     }
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpException.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpException.java
@@ -1,0 +1,15 @@
+package com.hubspot.smtp.client;
+
+public abstract class SmtpException extends Exception {
+  public SmtpException(String connectionId, String message) {
+    super(constructErrorMessage(connectionId, message));
+  }
+
+  private static String constructErrorMessage(String connectionId, String message) {
+    if (connectionId == null || connectionId.length() == 0) {
+      return message;
+    } else {
+      return String.format("[%s] %s", connectionId, message);
+    }
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -14,6 +14,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import com.hubspot.smtp.messages.MessageContent;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -66,8 +67,7 @@ public class SmtpSession {
   }
 
   public CompletableFuture<Void> close() {
-    CompletableFuture<Void> closeFuture = new CompletableFuture<>();
-    this.channel.close().addListener(f -> closeFuture.complete(null));
+    this.channel.close();
     return closeFuture;
   }
 
@@ -187,6 +187,7 @@ public class SmtpSession {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
       if (cause != null) {
         closeFuture.completeExceptionally(cause);

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -15,6 +15,8 @@ import com.google.common.collect.Sets;
 import com.hubspot.smtp.messages.MessageContent;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.smtp.SmtpCommand;
 import io.netty.handler.codec.smtp.SmtpRequest;
 import io.netty.handler.codec.smtp.SmtpResponse;
@@ -46,6 +48,7 @@ public class SmtpSession {
   private final Channel channel;
   private final ResponseHandler responseHandler;
   private final ExecutorService executorService;
+  private final CompletableFuture<Void> closeFuture;
 
   private volatile EnumSet<SupportedExtensions> supportedExtensions = EnumSet.noneOf(SupportedExtensions.class);
 
@@ -53,6 +56,13 @@ public class SmtpSession {
     this.channel = channel;
     this.responseHandler = responseHandler;
     this.executorService = executorService;
+    this.closeFuture = new CompletableFuture<>();
+
+    this.channel.pipeline().addLast(new ErrorHandler());
+  }
+
+  public CompletableFuture<Void> getCloseFuture() {
+    return closeFuture;
   }
 
   public CompletableFuture<Void> close() {
@@ -165,5 +175,26 @@ public class SmtpSession {
 
   public boolean isSupported(SupportedExtensions ext) {
     return supportedExtensions.contains(ext);
+  }
+
+  private class ErrorHandler extends ChannelInboundHandlerAdapter {
+    private Throwable cause;
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+      this.cause = cause;
+      ctx.close();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+      if (cause != null) {
+        closeFuture.completeExceptionally(cause);
+      } else {
+        closeFuture.complete(null);
+      }
+
+      super.channelInactive(ctx);
+    }
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
@@ -4,13 +4,17 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Optional;
 
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
+
+import com.google.common.base.Preconditions;
 
 @Immutable
 public abstract class SmtpSessionConfig {
   public abstract InetSocketAddress getRemoteAddress();
   public abstract Optional<InetSocketAddress> getLocalAddress();
+  public abstract Optional<Duration> getKeepAliveTimeout();
 
   @Default
   public Duration getReadTimeout() {
@@ -18,13 +22,14 @@ public abstract class SmtpSessionConfig {
   }
 
   @Default
-  public Duration getKeepAliveTimeout() {
-    return Duration.ofSeconds(30);
-  }
-
-  @Default
   public String getConnectionId() {
     return "unidentified-connection";
+  }
+
+  @Check
+  protected void check() {
+    Preconditions.checkState(!getKeepAliveTimeout().orElse(Duration.ofSeconds(1)).isZero(),
+        "keepAliveTimeout must not be zero; use Optional.empty() to disable keepalive");
   }
 
   public static ImmutableSmtpSessionConfig forRemoteAddress(String host, int port) {

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
@@ -18,15 +18,20 @@ public abstract class SmtpSessionConfig {
   }
 
   @Default
+  public Duration getKeepAliveTimeout() {
+    return Duration.ofSeconds(30);
+  }
+
+  @Default
   public String getConnectionId() {
     return "unidentified-connection";
   }
 
-  public static SmtpSessionConfig forRemoteAddress(String host, int port) {
+  public static ImmutableSmtpSessionConfig forRemoteAddress(String host, int port) {
     return forRemoteAddress(InetSocketAddress.createUnresolved(host, port));
   }
 
-  public static SmtpSessionConfig forRemoteAddress(InetSocketAddress remoteAddress) {
+  public static ImmutableSmtpSessionConfig forRemoteAddress(InetSocketAddress remoteAddress) {
     return ImmutableSmtpSessionConfig.builder().remoteAddress(remoteAddress).build();
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -82,6 +83,7 @@ public class SmtpSessionFactory implements Closeable  {
     }
   }
 
+  @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION") // https://github.com/findbugsproject/findbugs/issues/79
   public CompletableFuture<Void> closeAsync() {
     CompletableFuture<Void> returnedFuture = new CompletableFuture<>();
 

--- a/src/main/java/com/hubspot/smtp/utils/SmtpResponses.java
+++ b/src/main/java/com/hubspot/smtp/utils/SmtpResponses.java
@@ -1,0 +1,29 @@
+package com.hubspot.smtp.utils;
+
+import com.google.common.base.Joiner;
+
+import io.netty.handler.codec.smtp.SmtpResponse;
+
+public final class SmtpResponses {
+  private static final Joiner SPACE_JOINER = Joiner.on(" ");
+
+  private SmtpResponses() {
+    throw new AssertionError("Cannot create static utility class");
+  }
+
+  public static String toString(SmtpResponse response) {
+    return response.code() + " " + SPACE_JOINER.join(response.details());
+  }
+
+  public static boolean isTransientError(SmtpResponse response) {
+    return response.code() >= 400 && response.code() < 500;
+  }
+
+  public static boolean isPermanentError(SmtpResponse response) {
+    return response.code() >= 500;
+  }
+
+  public static boolean isError(SmtpResponse response) {
+    return isTransientError(response) || isPermanentError(response);
+  }
+}

--- a/src/test/java/com/hubspot/smtp/client/KeepAliveHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/KeepAliveHandlerTest.java
@@ -1,0 +1,144 @@
+package com.hubspot.smtp.client;
+
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.smtp.DefaultSmtpRequest;
+import io.netty.handler.codec.smtp.DefaultSmtpResponse;
+import io.netty.handler.codec.smtp.SmtpCommand;
+import io.netty.handler.codec.smtp.SmtpResponse;
+import io.netty.handler.timeout.IdleStateEvent;
+
+public class KeepAliveHandlerTest {
+  private static final String CONNECTION_ID = "connection";
+  private static final SmtpResponse OK_RESPONSE = new DefaultSmtpResponse(250);
+
+  private ChannelHandlerContext context;
+  private Channel channel;
+  private ResponseHandler responseHandler;
+  private TestHandler handler;
+
+  @Before
+  public void setup() {
+    context = mock(ChannelHandlerContext.class);
+    channel = mock(Channel.class);
+    responseHandler = mock(ResponseHandler.class);
+    handler = new TestHandler(responseHandler, CONNECTION_ID, Duration.ofSeconds(30));
+
+    when(context.channel()).thenReturn(channel);
+  }
+
+  @Test
+  public void itSendsANoopWhenTheIdleEventIsHandled() {
+    handler.triggerIdle();
+
+    verify(channel).writeAndFlush(new DefaultSmtpRequest(SmtpCommand.NOOP));
+  }
+
+  @Test
+  public void itDoesNotSendAnotherNoopIfOneIsPending() {
+    handler.triggerIdle();
+    handler.triggerIdle();
+
+    verify(channel, times(1)).writeAndFlush(new DefaultSmtpRequest(SmtpCommand.NOOP));
+  }
+
+  @Test
+  public void itDoesNotSendANoopIfACommandResponseIsPending() {
+    when(responseHandler.isResponsePending()).thenReturn(true);
+
+    handler.triggerIdle();
+
+    verifyZeroInteractions(channel);
+  }
+
+  @Test
+  public void itDoesNotPropagateReadEventsIfExpectingANoopResponse() throws Exception {
+    handler.triggerIdle();
+    handler.channelRead(context, OK_RESPONSE);
+
+    verify(context, never()).fireChannelRead(any());
+  }
+
+  @Test
+  public void itPropagatesReadEventsIfNotExpectingANoopResponse() throws Exception {
+    handler.channelRead(context, OK_RESPONSE);
+
+    verify(context).fireChannelRead(OK_RESPONSE);
+  }
+
+  @Test
+  public void itPropagatesReadEventsOnceANoopResponseHasBeenProcessed() throws Exception {
+    handler.triggerIdle();
+
+    // response suppressed
+    handler.channelRead(context, OK_RESPONSE);
+    verify(context, never()).fireChannelRead(any());
+
+    // response propagated
+    handler.channelRead(context, OK_RESPONSE);
+    verify(context).fireChannelRead(OK_RESPONSE);
+  }
+
+  @Test
+  public void itPropagatesReadEventsIfTheyAreNotSmtpResponse() throws Exception {
+    Object obj = new Object();
+    handler.triggerIdle();
+
+    handler.channelRead(context, obj);
+
+    verify(context).fireChannelRead(obj);
+  }
+
+  @Test
+  public void itQueuesWritesWhileANoopResponseIsPending() throws Exception {
+    Object message1 = new Object();
+    Object message2 = new Object();
+    ChannelPromise promise1 = mockPromiseWithUnvoid();
+    ChannelPromise promise2 = mockPromiseWithUnvoid();
+
+    handler.triggerIdle();
+
+    // waiting for noop response
+    handler.write(context, message1, promise1);
+    handler.write(context, message2, promise2);
+
+    // not sent yet
+    verify(context, never()).write(any(), any());
+
+    // noop response received
+    handler.channelRead(context, OK_RESPONSE);
+
+    // sent now
+    verify(context).write(message1, promise1);
+    verify(context).write(message2, promise2);
+  }
+
+  private ChannelPromise mockPromiseWithUnvoid() {
+    // IdleStateHandler calls unvoid on the promise to ensure it can attach a listener
+    ChannelPromise p = mock(ChannelPromise.class);
+    when(p.unvoid()).thenReturn(p);
+    return p;
+  }
+
+  private class TestHandler extends KeepAliveHandler {
+    TestHandler(ResponseHandler responseHandler, String connectionId, Duration idleTimeout) {
+      super(responseHandler, connectionId, idleTimeout);
+    }
+
+    void triggerIdle() {
+      try {
+        channelIdle(context, IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -146,4 +146,25 @@ public class ResponseHandlerTest {
 
     responseHandler.createResponseFuture(1, DEBUG_STRING);
   }
+
+  @Test
+  public void itCanTellWhenAResponseIsPending() {
+    assertThat(responseHandler.isResponsePending()).isFalse();
+
+    responseHandler.createResponseFuture(1, DEBUG_STRING);
+
+    assertThat(responseHandler.isResponsePending()).isTrue();
+  }
+
+  @Test
+  public void itCompletesExceptionallyIfTheChannelIsClosed() throws Exception {
+    CompletableFuture<SmtpResponse[]> f = responseHandler.createResponseFuture(1, DEBUG_STRING);
+
+    responseHandler.channelInactive(context);
+
+    assertThat(f.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(f::get)
+        .hasCauseInstanceOf(ChannelClosedException.class)
+        .hasMessageEndingWith(CONNECTION_ID_PREFIX + "Handled channelInactive while waiting for a response to [" + DEBUG_STRING.get() + "]");
+  }
 }

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -39,6 +39,8 @@ public class ResponseHandlerTest {
 
     assertThat(f.isCompletedExceptionally()).isTrue();
     assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class).hasCause(testException);
+
+    verify(context).fireExceptionCaught(testException);
   }
 
   @Test

--- a/src/test/java/com/hubspot/smtp/utils/SmtpResponsesTest.java
+++ b/src/test/java/com/hubspot/smtp/utils/SmtpResponsesTest.java
@@ -1,0 +1,40 @@
+package com.hubspot.smtp.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.netty.handler.codec.smtp.DefaultSmtpResponse;
+import io.netty.handler.codec.smtp.SmtpResponse;
+
+public class SmtpResponsesTest {
+  private static final SmtpResponse OK_RESPONSE = new DefaultSmtpResponse(250, "ARG1", "ARG2");
+  private static final SmtpResponse TRANSIENT_ERROR_RESPONSE = new DefaultSmtpResponse(400);
+  private static final SmtpResponse PERMANENT_ERROR_RESPONSE = new DefaultSmtpResponse(500);
+
+  @Test
+  public void itFormatsResponsesAsAString() {
+    assertThat(SmtpResponses.toString(OK_RESPONSE)).isEqualTo("250 ARG1 ARG2");
+  }
+
+  @Test
+  public void itCanDetectTransientErrors() {
+    assertThat(SmtpResponses.isTransientError(OK_RESPONSE)).isFalse();
+    assertThat(SmtpResponses.isTransientError(PERMANENT_ERROR_RESPONSE)).isFalse();
+    assertThat(SmtpResponses.isTransientError(TRANSIENT_ERROR_RESPONSE)).isTrue();
+  }
+
+  @Test
+  public void itCanDetectPermanenetErrors() {
+    assertThat(SmtpResponses.isPermanentError(OK_RESPONSE)).isFalse();
+    assertThat(SmtpResponses.isPermanentError(TRANSIENT_ERROR_RESPONSE)).isFalse();
+    assertThat(SmtpResponses.isPermanentError(PERMANENT_ERROR_RESPONSE)).isTrue();
+  }
+
+  @Test
+  public void itCanDetectErrors() {
+    assertThat(SmtpResponses.isError(OK_RESPONSE)).isFalse();
+    assertThat(SmtpResponses.isError(TRANSIENT_ERROR_RESPONSE)).isTrue();
+    assertThat(SmtpResponses.isError(PERMANENT_ERROR_RESPONSE)).isTrue();
+  }
+}


### PR DESCRIPTION
`KeepAliveHandler` extends `IdleStateHandler` to track when nothing has been sent or received for the duration defined by `SmtpSessionConfig::getKeepAliveTimeout`. If nothing has been sent/received, `KeepAliveHandler` sends a NOOP to the remote server and sets an `expectingNoopResponse` flag. `KeepAliveHandler` overrides `channelRead` to intercept responses and drops the first one it sees if `expectingNoopResponse` is set. This prevents `ResponseHandler` from logging a warning if it receives the NOOP response.

If we're waiting for a NOOP response when the timer fires, we don't send another. If we're waiting for a response to a non-NOOP command, we don't send a NOOP. If a request is sent while we're waiting for a NOOP response, we queue it and send when the NOOP response arrives. These rules help us maintain the request-reply interaction model even though there are two actors (our client and the timer) using the channel.

A client can't send a request between the detection of an idle condition and us sending the NOOP because requests are always sent on the event loop thread. (`send` can be called from a different thread, but if you're not on the event loop thread Netty will use the executor to schedule the send.) 

@axiak 