### PR TITLE
Fix memory leak

### DIFF
--- a/src/main/java/com/hubspot/smtp/messages/DotStuffing.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffing.java
@@ -45,7 +45,7 @@ final class DotStuffing {
       if (termination == MessageTermination.ADD_CRLF) {
         return allocator.compositeBuffer(2).addComponents(true, sourceBuffer.retainedSlice(), CR_LF_BUFFER.slice());
       } else {
-        return sourceBuffer.retain();
+        return sourceBuffer;
       }
     }
 

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingTest.java
@@ -64,23 +64,6 @@ public class DotStuffingTest {
     destBuffer.release();
   }
 
-  @Test
-  public void itRetainsTheSourceByteIfNoProcessingIsRequired() {
-    String testString = "abc";
-
-    ByteBuf sourceBuffer = ALLOCATOR.buffer();
-    sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
-    assertThat(sourceBuffer.refCnt()).isEqualTo(1);
-
-    ByteBuf destBuffer = DotStuffing.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, MessageTermination.DO_NOT_TERMINATE);
-    assertThat(destBuffer).isSameAs(sourceBuffer);
-    assertThat(sourceBuffer.refCnt()).isEqualTo(2);
-
-    // should be able to release both of these successfully
-    sourceBuffer.release();
-    destBuffer.release();
-  }
-
   private String dotStuffUsingByteBuf(String testString) {
     return dotStuffUsingByteBuf(testString, true, true);
   }


### PR DESCRIPTION
We don't need to retain this buffer if we're returning it directly.

@axiak