### PR TITLE
Support auth plain and auth login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
       <artifactId>protocols-smtp</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/hubspot/smtp/TestApp.java
+++ b/src/main/java/com/hubspot/smtp/TestApp.java
@@ -10,8 +10,6 @@ import static io.netty.handler.codec.smtp.SmtpCommand.RSET;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.EnumSet;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -19,14 +17,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Splitter;
 import com.google.common.base.Stopwatch;
 import com.hubspot.smtp.client.SmtpClientResponse;
 import com.hubspot.smtp.client.SmtpSession;
 import com.hubspot.smtp.client.SmtpSessionConfig;
 import com.hubspot.smtp.client.SmtpSessionFactory;
-import com.hubspot.smtp.client.SupportedExtensions;
 import com.hubspot.smtp.messages.MessageContent;
 
 import io.netty.buffer.ByteBuf;
@@ -129,22 +124,7 @@ class TestApp {
     }
 
     CompletableFuture<SmtpClientResponse> ehlo(SmtpSession session, String greetingName) {
-      return send(session, request(EHLO, greetingName)).whenComplete((response, cause) -> {
-        if (response != null) {
-          setSupportedExtensions(session, response.details());
-        }
-      });
-    }
-
-    private void setSupportedExtensions(SmtpSession session, List<CharSequence> details) {
-      EnumSet<SupportedExtensions> discoveredExtensions = EnumSet.noneOf(SupportedExtensions.class);
-
-      for (CharSequence ext : details) {
-        List<String> parts = Splitter.on(CharMatcher.WHITESPACE).splitToList(ext);
-        SupportedExtensions.find(parts.get(0)).ifPresent(discoveredExtensions::add);
-      }
-
-      session.setSupportedExtensions(discoveredExtensions);
+      return send(session, request(EHLO, greetingName));
     }
 
     CompletableFuture<SmtpClientResponse> mail(SmtpSession session, String from) {

--- a/src/main/java/com/hubspot/smtp/client/Extension.java
+++ b/src/main/java/com/hubspot/smtp/client/Extension.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public enum SupportedExtensions {
+public enum Extension {
   AUTH("auth"),
   DSN("dsn"),
   EIGHT_BIT_MIME("8bitmime"),
@@ -18,14 +18,14 @@ public enum SupportedExtensions {
 
   private final String lowerCaseName;
 
-  private static Map<String, SupportedExtensions> NAME_TO_EXTENSION = Arrays.stream(SupportedExtensions.values())
-      .collect(Collectors.toMap(SupportedExtensions::getLowerCaseName, v -> v));
+  private static Map<String, Extension> NAME_TO_EXTENSION = Arrays.stream(Extension.values())
+      .collect(Collectors.toMap(Extension::getLowerCaseName, v -> v));
 
-  public static Optional<SupportedExtensions> find(String name) {
+  public static Optional<Extension> find(String name) {
     return Optional.ofNullable(NAME_TO_EXTENSION.get(name.toLowerCase()));
   }
 
-  SupportedExtensions(String lowerCaseName) {
+  Extension(String lowerCaseName) {
     this.lowerCaseName = lowerCaseName;
   }
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -71,7 +71,7 @@ public class SmtpSession {
   private final SmtpSessionConfig config;
   private final CompletableFuture<Void> closeFuture;
 
-  private volatile EnumSet<SupportedExtensions> supportedExtensions = EnumSet.noneOf(SupportedExtensions.class);
+  private volatile EnumSet<Extension> supportedExtensions = EnumSet.noneOf(Extension.class);
   private volatile boolean isAuthPlainSupported;
   private volatile boolean isAuthLoginSupported;
 
@@ -156,7 +156,7 @@ public class SmtpSession {
   }
 
   public CompletableFuture<SmtpClientResponse[]> sendPipelined(MessageContent content, SmtpRequest... requests) {
-    Preconditions.checkState(isSupported(SupportedExtensions.PIPELINING), "Pipelining is not supported on this server");
+    Preconditions.checkState(isSupported(Extension.PIPELINING), "Pipelining is not supported on this server");
     Preconditions.checkNotNull(requests);
     checkValidPipelinedRequest(requests);
 
@@ -223,7 +223,7 @@ public class SmtpSession {
   }
 
   private void writeContent(MessageContent content) {
-    if (isSupported(SupportedExtensions.EIGHT_BIT_MIME)) {
+    if (isSupported(Extension.EIGHT_BIT_MIME)) {
       channel.write(content.get8BitMimeEncodedContent());
     } else {
       channel.write(content.get7BitEncodedContent());
@@ -251,11 +251,11 @@ public class SmtpSession {
     isAuthLoginSupported = false;
     isAuthPlainSupported = false;
 
-    EnumSet<SupportedExtensions> discoveredExtensions = EnumSet.noneOf(SupportedExtensions.class);
+    EnumSet<Extension> discoveredExtensions = EnumSet.noneOf(Extension.class);
 
     for (CharSequence ext : details) {
       List<String> parts = WHITESPACE_SPLITTER.splitToList(ext);
-      SupportedExtensions.find(parts.get(0)).ifPresent(discoveredExtensions::add);
+      Extension.find(parts.get(0)).ifPresent(discoveredExtensions::add);
 
       if (parts.get(0).equalsIgnoreCase("auth") && parts.size() > 1) {
         for (int i = 1; i < parts.size(); i++) {
@@ -313,7 +313,7 @@ public class SmtpSession {
     }, executorService);
   }
 
-  public boolean isSupported(SupportedExtensions ext) {
+  public boolean isSupported(Extension ext) {
     return supportedExtensions.contains(ext);
   }
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -3,6 +3,7 @@ package com.hubspot.smtp.client;
 import static io.netty.handler.codec.smtp.LastSmtpContent.EMPTY_LAST_CONTENT;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.EnumSet;
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
@@ -269,8 +271,15 @@ public class SmtpSession {
     this.supportedExtensions = discoveredExtensions;
   }
 
-  private static String createDebugString(SmtpRequest... requests) {
-    return COMMA_JOINER.join(requests);
+  @VisibleForTesting
+  static String createDebugString(SmtpRequest... requests) {
+    return COMMA_JOINER.join(Arrays.stream(requests)
+        .map(r -> r.command().equals(AUTH_COMMAND) ? "<redacted-auth-command>" : requestToString(r))
+        .collect(Collectors.toList()));
+  }
+
+  private static  String requestToString(SmtpRequest request) {
+    return String.format("%s %s", request.command().name(), Joiner.on(" ").join(request.parameters()));
   }
 
   private static void checkValidPipelinedRequest(SmtpRequest[] requests) {

--- a/src/main/java/com/hubspot/smtp/client/SupportedExtensions.java
+++ b/src/main/java/com/hubspot/smtp/client/SupportedExtensions.java
@@ -6,13 +6,15 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public enum SupportedExtensions {
-  PIPELINING("pipelining"),
-  EIGHT_BIT_MIME("8bitmime"),
   AUTH("auth"),
-  XCLIENT("xclient"),
-  XFORWARD("xforward"),
+  DSN("dsn"),
+  EIGHT_BIT_MIME("8bitmime"),
   ENHANCEDSTATUSCODES("enhancedstatuscodes"),
-  DSN("dsn");
+  PIPELINING("pipelining"),
+  SIZE("size"),
+  STARTTLS("starttls"),
+  XCLIENT("xclient"),
+  XFORWARD("xforward");
 
   private final String lowerCaseName;
 

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -42,6 +42,7 @@ import com.hubspot.smtp.client.SmtpClientResponse;
 import com.hubspot.smtp.client.SmtpSession;
 import com.hubspot.smtp.client.SmtpSessionConfig;
 import com.hubspot.smtp.client.SmtpSessionFactory;
+import com.hubspot.smtp.client.SupportedExtensions;
 import com.hubspot.smtp.messages.MessageContent;
 
 import io.netty.buffer.PooledByteBufAllocator;
@@ -95,6 +96,19 @@ public class IntegrationTest {
   @After
   public void after() {
     smtpServer.unbind();
+  }
+
+  @Test
+  public void itCanParseTheEhloResponse() throws Exception {
+    connect()
+        .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
+        .thenCompose(r -> {
+          assertThat(r.getSession().isSupported(SupportedExtensions.PIPELINING)).isTrue();
+          assertThat(r.getSession().isSupported(SupportedExtensions.EIGHT_BIT_MIME)).isTrue();
+          return r.getSession().send(req(QUIT));
+        })
+        .thenCompose(r -> assertSuccess(r).close())
+        .get();
   }
 
   @Test

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -43,7 +43,7 @@ import com.hubspot.smtp.client.SmtpClientResponse;
 import com.hubspot.smtp.client.SmtpSession;
 import com.hubspot.smtp.client.SmtpSessionConfig;
 import com.hubspot.smtp.client.SmtpSessionFactory;
-import com.hubspot.smtp.client.SupportedExtensions;
+import com.hubspot.smtp.client.Extension;
 import com.hubspot.smtp.messages.MessageContent;
 
 import io.netty.buffer.PooledByteBufAllocator;
@@ -112,8 +112,8 @@ public class IntegrationTest {
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> {
-          assertThat(r.getSession().isSupported(SupportedExtensions.PIPELINING)).isTrue();
-          assertThat(r.getSession().isSupported(SupportedExtensions.EIGHT_BIT_MIME)).isTrue();
+          assertThat(r.getSession().isSupported(Extension.PIPELINING)).isTrue();
+          assertThat(r.getSession().isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
           return r.getSession().send(req(QUIT));
         })
         .thenCompose(r -> assertSuccess(r).close())
@@ -127,7 +127,7 @@ public class IntegrationTest {
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> {
-          assertThat(r.getSession().isSupported(SupportedExtensions.AUTH)).isTrue();
+          assertThat(r.getSession().isSupported(Extension.AUTH)).isTrue();
           assertThat(r.getSession().isAuthPlainSupported()).isTrue();
           return r.getSession().authPlain(CORRECT_USERNAME, CORRECT_PASSWORD);
         })
@@ -142,7 +142,7 @@ public class IntegrationTest {
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> {
-          assertThat(r.getSession().isSupported(SupportedExtensions.AUTH)).isTrue();
+          assertThat(r.getSession().isSupported(Extension.AUTH)).isTrue();
           assertThat(r.getSession().isAuthLoginSupported()).isTrue();
           return r.getSession().authLogin(CORRECT_USERNAME, CORRECT_PASSWORD);
         })

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -119,11 +119,11 @@ public class SmtpSessionTest {
         "STARTTLS",
         "SIZE") });
 
-    assertThat(session.isSupported(SupportedExtensions.EIGHT_BIT_MIME)).isTrue();
-    assertThat(session.isSupported(SupportedExtensions.STARTTLS)).isTrue();
-    assertThat(session.isSupported(SupportedExtensions.SIZE)).isTrue();
+    assertThat(session.isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
+    assertThat(session.isSupported(Extension.STARTTLS)).isTrue();
+    assertThat(session.isSupported(Extension.SIZE)).isTrue();
 
-    assertThat(session.isSupported(SupportedExtensions.PIPELINING)).isFalse();
+    assertThat(session.isSupported(Extension.PIPELINING)).isFalse();
 
     assertThat(session.isAuthPlainSupported()).isTrue();
     assertThat(session.isAuthLoginSupported()).isTrue();
@@ -136,10 +136,10 @@ public class SmtpSessionTest {
     responseFuture.complete(new SmtpResponse[] { new DefaultSmtpResponse(250,
         "smtp.example.com Hello client.example.com") });
 
-    assertThat(session.isSupported(SupportedExtensions.EIGHT_BIT_MIME)).isFalse();
-    assertThat(session.isSupported(SupportedExtensions.STARTTLS)).isFalse();
-    assertThat(session.isSupported(SupportedExtensions.SIZE)).isFalse();
-    assertThat(session.isSupported(SupportedExtensions.PIPELINING)).isFalse();
+    assertThat(session.isSupported(Extension.EIGHT_BIT_MIME)).isFalse();
+    assertThat(session.isSupported(Extension.STARTTLS)).isFalse();
+    assertThat(session.isSupported(Extension.SIZE)).isFalse();
+    assertThat(session.isSupported(Extension.PIPELINING)).isFalse();
 
     assertThat(session.isAuthPlainSupported()).isFalse();
     assertThat(session.isAuthLoginSupported()).isFalse();

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -304,6 +304,19 @@ public class SmtpSessionTest {
     assertThat(f.get().code()).isEqualTo(FAIL_RESPONSE.code());
   }
 
+  @Test
+  public void itRedactsAuthCommandsInTheDebugString() {
+    assertThat(SmtpSession.createDebugString(new DefaultSmtpRequest("AUTH", "super-secret")))
+        .isEqualTo("<redacted-auth-command>");
+  }
+
+  @Test
+  public void itIncludesCommandsAndArgsInTheDebugString() {
+    assertThat(SmtpSession.createDebugString(new DefaultSmtpRequest("EHLO", "example.com"), new DefaultSmtpRequest("AUTH", "super-secret")))
+        .isEqualTo("EHLO example.com, <redacted-auth-command>");
+
+  }
+
   private String encodeBase64(String s) {
     return Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8));
   }


### PR DESCRIPTION
This PR introduces better parsing of the EHLO response and support for authenticating with the PLAIN or LOGIN mechanisms. 

Supported extensions are now parsed for you when EHLO returns, and exposed through the `isSupported` method on `SmtpSession`. The supported auth mechanisms are available through `isAuthPlainSupported` and `isAuthLoginSupported`.

If the EHLO response indicates an auth mechanism is supported, you can authenticate using `authPlain` or `authLogin`.

Because they might contain sensitive information we don't want in logs, a redacted version is included in the `debugString` sent to ResponseHandler

@axiak 