### PR TITLE
Direct executor

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -13,6 +13,8 @@ import javax.net.ssl.TrustManagerFactory;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
+import org.immutables.value.Value.Style.ImplementationVisibility;
 
 import com.google.common.base.Preconditions;
 
@@ -21,7 +23,8 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.handler.ssl.SslContextBuilder;
 
 @Immutable
-public abstract class SmtpSessionConfig {
+@Style(typeImmutable = "*", visibility = ImplementationVisibility.PUBLIC)
+abstract class AbstractSmtpSessionConfig {
   public static final Executor DIRECT_EXECUTOR = Runnable::run;
 
   public abstract InetSocketAddress getRemoteAddress();
@@ -70,11 +73,11 @@ public abstract class SmtpSessionConfig {
     }
   }
 
-  public static ImmutableSmtpSessionConfig forRemoteAddress(String host, int port) {
+  public static SmtpSessionConfig forRemoteAddress(String host, int port) {
     return forRemoteAddress(InetSocketAddress.createUnresolved(host, port));
   }
 
-  public static ImmutableSmtpSessionConfig forRemoteAddress(InetSocketAddress remoteAddress) {
-    return ImmutableSmtpSessionConfig.builder().remoteAddress(remoteAddress).build();
+  public static SmtpSessionConfig forRemoteAddress(InetSocketAddress remoteAddress) {
+    return SmtpSessionConfig.builder().remoteAddress(remoteAddress).build();
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionConfig.java
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLEngine;
@@ -21,9 +22,12 @@ import io.netty.handler.ssl.SslContextBuilder;
 
 @Immutable
 public abstract class SmtpSessionConfig {
+  public static final Executor DIRECT_EXECUTOR = Runnable::run;
+
   public abstract InetSocketAddress getRemoteAddress();
   public abstract Optional<InetSocketAddress> getLocalAddress();
   public abstract Optional<Duration> getKeepAliveTimeout();
+  public abstract Optional<Executor> getExecutor();
 
   @Default
   public Duration getReadTimeout() {

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -54,7 +54,7 @@ public class SmtpSessionFactory implements Closeable  {
         Channel channel = ((ChannelFuture) f).channel();
         allChannels.add(channel);
 
-        SmtpSession session = new SmtpSession(channel, responseHandler, executorService, config);
+        SmtpSession session = new SmtpSession(channel, responseHandler, config);
         applyOnExecutor(initialResponseFuture, r -> connectFuture.complete(new SmtpClientResponse(r[0], session)));
       } else {
         LOG.error("Could not connect to {}", config.getRemoteAddress(), f.cause());

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -57,7 +57,7 @@ public class SmtpSessionTest {
   private static final SmtpRequest HELO_REQUEST = new DefaultSmtpRequest(SmtpCommand.HELO);
   private static final SmtpRequest HELP_REQUEST = new DefaultSmtpRequest(SmtpCommand.HELP);
 
-  private static final ImmutableSmtpSessionConfig CONFIG = SmtpSessionConfig.forRemoteAddress("127.0.0.1", 25).withExecutor(SmtpSessionConfig.DIRECT_EXECUTOR);
+  private static final SmtpSessionConfig CONFIG = SmtpSessionConfig.forRemoteAddress("127.0.0.1", 25).withExecutor(SmtpSessionConfig.DIRECT_EXECUTOR);
 
   private ResponseHandler responseHandler;
   private CompletableFuture<SmtpResponse[]> responseFuture;


### PR DESCRIPTION
Makes it easy and efficient to execute callbacks on the event loop thread by passing `SmtpSessionConfig.DIRECT_EXECUTOR` when building the config.

Fixes https://github.com/HubSpot/NioSmtpClient/issues/7.

Note this isn't quite the same pattern as in [GRPC](https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/ManagedChannelBuilder.java#L80-L91). Immutables doesn't (afaict) support having one builder method set the value of another property which is how GRPC [implements](https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/internal/AbstractManagedChannelImplBuilder.java#L164-L167) this. Having two values, e.g. `getDirectExecutor(boolean)` and `getExecutor(Executor)` makes it hard to know which value should take precedence, especially when constructing a derived config:

```
SmtpSessionConfig.builder()
    .executor(Executors.newCachedThreadPool())
    .build().withDirectExecutor(true);

SmtpSessionConfig.builder()
    .directExecutor(true)
    build().withExecutor(Executors.newCachedThreadPool());
```

Instead, this PR uses a single `Optional<Executor>` field that you can set to the `DIRECT_EXECUTOR` constant. If the optional is empty, we use `ForkJoinPool.commonPool()` instead.

@axiak 
