### PR TITLE
Support the message size extension

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/EhloResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/EhloResponse.java
@@ -1,0 +1,60 @@
+package com.hubspot.smtp.client;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+
+public class EhloResponse {
+  private static final Splitter WHITESPACE_SPLITTER = Splitter.on(CharMatcher.WHITESPACE);
+
+  static final EhloResponse NULL_RESPONSE = EhloResponse.parse(Collections.emptyList());
+
+  private final EnumSet<Extension> supportedExtensions;
+  private final boolean isAuthPlainSupported;
+  private final boolean isAuthLoginSupported;
+
+  public static EhloResponse parse(Iterable<CharSequence> lines) {
+    boolean isAuthLoginSupported = false;
+    boolean isAuthPlainSupported = false;
+
+    EnumSet<Extension> discoveredExtensions = EnumSet.noneOf(Extension.class);
+
+    for (CharSequence ext : lines) {
+      List<String> parts = WHITESPACE_SPLITTER.splitToList(ext);
+      Extension.find(parts.get(0)).ifPresent(discoveredExtensions::add);
+
+      if (parts.get(0).equalsIgnoreCase("auth") && parts.size() > 1) {
+        for (int i = 1; i < parts.size(); i++) {
+          if (parts.get(i).equalsIgnoreCase("plain")) {
+            isAuthPlainSupported = true;
+          } else if (parts.get(i).equalsIgnoreCase("login")) {
+            isAuthLoginSupported = true;
+          }
+        }
+      }
+    }
+
+    return new EhloResponse(discoveredExtensions, isAuthPlainSupported, isAuthLoginSupported);
+  }
+
+  private EhloResponse(EnumSet<Extension> supportedExtensions, boolean isAuthPlainSupported, boolean isAuthLoginSupported) {
+    this.supportedExtensions = supportedExtensions;
+    this.isAuthPlainSupported = isAuthPlainSupported;
+    this.isAuthLoginSupported = isAuthLoginSupported;
+  }
+
+  public boolean isSupported(Extension ext) {
+    return supportedExtensions.contains(ext);
+  }
+
+  public boolean isAuthPlainSupported() {
+    return isAuthPlainSupported;
+  }
+
+  public boolean isAuthLoginSupported() {
+    return isAuthLoginSupported;
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/MessageTooLargeException.java
+++ b/src/main/java/com/hubspot/smtp/client/MessageTooLargeException.java
@@ -1,0 +1,7 @@
+package com.hubspot.smtp.client;
+
+public class MessageTooLargeException extends SmtpException {
+  public MessageTooLargeException(String connectionId, long maxMessageSize) {
+    super(connectionId, String.format("This message is too large to be sent (max size: %d)", maxMessageSize));
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -210,9 +210,12 @@ public class SmtpSession {
   }
 
   private void checkMessageSize(MessageContent content) {
-    if (content != null && ehloResponse.getMaxMessageSize().isPresent()) {
-      Preconditions.checkArgument(ehloResponse.getMaxMessageSize().get() > content.size(),
-          String.format("This message is too large to be sent (EHLO-advertised limit: %d)", ehloResponse.getMaxMessageSize().get()));
+    if (content == null || !ehloResponse.getMaxMessageSize().isPresent()) {
+      return;
+    }
+
+    if (ehloResponse.getMaxMessageSize().get() < content.size()) {
+      throw new MessageTooLargeException(config.getConnectionId(), ehloResponse.getMaxMessageSize().get());
     }
   }
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -66,7 +66,7 @@ public class SmtpSession {
   private final SmtpSessionConfig config;
   private final CompletableFuture<Void> closeFuture;
 
-  private volatile EhloResponse ehloResponse = EhloResponse.NULL_RESPONSE;
+  private volatile EhloResponse ehloResponse = EhloResponse.EMPTY;
 
   SmtpSession(Channel channel, ResponseHandler responseHandler, ExecutorService executorService, SmtpSessionConfig config) {
     this.channel = channel;

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -114,8 +114,8 @@ public class IntegrationTest {
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> {
-          assertThat(r.getSession().isSupported(Extension.PIPELINING)).isTrue();
-          assertThat(r.getSession().isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
+          assertThat(r.getSession().getEhloResponse().isSupported(Extension.PIPELINING)).isTrue();
+          assertThat(r.getSession().getEhloResponse().isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
           return r.getSession().send(req(QUIT));
         })
         .thenCompose(r -> assertSuccess(r).close())
@@ -129,8 +129,8 @@ public class IntegrationTest {
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> {
-          assertThat(r.getSession().isSupported(Extension.AUTH)).isTrue();
-          assertThat(r.getSession().isAuthPlainSupported()).isTrue();
+          assertThat(r.getSession().getEhloResponse().isSupported(Extension.AUTH)).isTrue();
+          assertThat(r.getSession().getEhloResponse().isAuthPlainSupported()).isTrue();
           return r.getSession().authPlain(CORRECT_USERNAME, CORRECT_PASSWORD);
         })
         .thenCompose(r -> assertSuccess(r).close())
@@ -144,8 +144,8 @@ public class IntegrationTest {
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> {
-          assertThat(r.getSession().isSupported(Extension.AUTH)).isTrue();
-          assertThat(r.getSession().isAuthLoginSupported()).isTrue();
+          assertThat(r.getSession().getEhloResponse().isSupported(Extension.AUTH)).isTrue();
+          assertThat(r.getSession().getEhloResponse().isAuthLoginSupported()).isTrue();
           return r.getSession().authLogin(CORRECT_USERNAME, CORRECT_PASSWORD);
         })
         .thenCompose(r -> assertSuccess(r).close())

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -1,0 +1,83 @@
+package com.hubspot.smtp.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class EhloResponseTest {
+  @Test
+  public void itHasAnEmptyResponseThatSupportsNothing() {
+    assertThat(EhloResponse.EMPTY.isSupported(Extension.PIPELINING)).isFalse();
+    assertThat(EhloResponse.EMPTY.isAuthPlainSupported()).isFalse();
+    assertThat(EhloResponse.EMPTY.isAuthLoginSupported()).isFalse();
+  }
+  
+  @Test
+  public void itParsesATypicalResponse() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com",
+        "AUTH PLAIN LOGIN",
+        "8BITMIME",
+        "STARTTLS",
+        "SIZE");
+
+    assertThat(response.isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
+    assertThat(response.isSupported(Extension.STARTTLS)).isTrue();
+    assertThat(response.isSupported(Extension.SIZE)).isTrue();
+
+    assertThat(response.isSupported(Extension.PIPELINING)).isFalse();
+
+    assertThat(response.isAuthPlainSupported()).isTrue();
+    assertThat(response.isAuthLoginSupported()).isTrue();
+  }
+
+  @Test
+  public void itParsesEightBitMime() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "8BITMIME");
+    assertThat(response.isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
+  }
+
+  @Test
+  public void itParsesStartTls() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "STARTTLS");
+    assertThat(response.isSupported(Extension.STARTTLS)).isTrue();
+  }
+
+  @Test
+  public void itParsesPipelining() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "PIPELINING");
+    assertThat(response.isSupported(Extension.PIPELINING)).isTrue();
+  }
+
+  @Test
+  public void itParsesAuth() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "AUTH PLAIN LOGIN");
+    assertThat(response.isAuthPlainSupported()).isTrue();
+    assertThat(response.isAuthLoginSupported()).isTrue();
+  }
+
+  @Test
+  public void itParsesSize() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "SIZE");
+    assertThat(response.isSupported(Extension.SIZE)).isTrue();
+  }
+
+  @Test
+  public void itParsesSizeWithASpecifiedSize() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "SIZE 1234000");
+    assertThat(response.isSupported(Extension.SIZE)).isTrue();
+    assertThat(response.getMaxMessageSize()).contains(1234000L);
+  }
+
+  @Test
+  public void itIgnoresInvalidSizes() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "SIZE abc");
+    assertThat(response.isSupported(Extension.SIZE)).isTrue();
+    assertThat(response.getMaxMessageSize()).isEmpty();
+  }
+
+  private EhloResponse parse(CharSequence... lines) {
+    return EhloResponse.parse(Lists.newArrayList(lines));
+  }
+}

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class EhloResponseTest {
   @Test
@@ -30,6 +31,21 @@ public class EhloResponseTest {
 
     assertThat(response.isAuthPlainSupported()).isTrue();
     assertThat(response.isAuthLoginSupported()).isTrue();
+  }
+
+  @Test
+  public void itExposesSupportedExtensionsAsStrings() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com",
+        "AUTH PLAIN LOGIN",
+        "8BITMIME",
+        "STARTTLS",
+        "SIZE");
+
+    assertThat(response.getSupportedExtensions()).isEqualTo(Sets.newHashSet("smtp.example.com Hello client.example.com",
+        "AUTH PLAIN LOGIN",
+        "8BITMIME",
+        "STARTTLS",
+        "SIZE"));
   }
 
   @Test

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -105,8 +105,8 @@ public class SmtpSessionTest {
     MessageContent largeMessage = MessageContent.of(ByteSource.wrap(new byte[0]), 1025, MessageContentEncoding.ASSUME_DOT_STUFFED);
 
     assertThatThrownBy(() -> session.send(largeMessage))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("This message is too large to be sent (EHLO-advertised limit: 1024)");
+      .isInstanceOf(MessageTooLargeException.class)
+      .hasMessage("[unidentified-connection] This message is too large to be sent (max size: 1024)");
   }
 
   @Test

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -77,7 +77,7 @@ public class SmtpSessionTest {
     when(channel.alloc()).thenReturn(new PooledByteBufAllocator(false));
 
     session = new SmtpSession(channel, responseHandler, EXECUTOR_SERVICE, CONFIG);
-    session.setSupportedExtensions(Lists.newArrayList("PIPELINING", "AUTH PLAIN LOGIN"));
+    session.parseEhloResponse(Lists.newArrayList("PIPELINING", "AUTH PLAIN LOGIN"));
   }
   
   @Test
@@ -119,14 +119,14 @@ public class SmtpSessionTest {
         "STARTTLS",
         "SIZE") });
 
-    assertThat(session.isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
-    assertThat(session.isSupported(Extension.STARTTLS)).isTrue();
-    assertThat(session.isSupported(Extension.SIZE)).isTrue();
+    assertThat(session.getEhloResponse().isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
+    assertThat(session.getEhloResponse().isSupported(Extension.STARTTLS)).isTrue();
+    assertThat(session.getEhloResponse().isSupported(Extension.SIZE)).isTrue();
 
-    assertThat(session.isSupported(Extension.PIPELINING)).isFalse();
+    assertThat(session.getEhloResponse().isSupported(Extension.PIPELINING)).isFalse();
 
-    assertThat(session.isAuthPlainSupported()).isTrue();
-    assertThat(session.isAuthLoginSupported()).isTrue();
+    assertThat(session.getEhloResponse().isAuthPlainSupported()).isTrue();
+    assertThat(session.getEhloResponse().isAuthLoginSupported()).isTrue();
   }
 
   @Test
@@ -136,13 +136,13 @@ public class SmtpSessionTest {
     responseFuture.complete(new SmtpResponse[] { new DefaultSmtpResponse(250,
         "smtp.example.com Hello client.example.com") });
 
-    assertThat(session.isSupported(Extension.EIGHT_BIT_MIME)).isFalse();
-    assertThat(session.isSupported(Extension.STARTTLS)).isFalse();
-    assertThat(session.isSupported(Extension.SIZE)).isFalse();
-    assertThat(session.isSupported(Extension.PIPELINING)).isFalse();
+    assertThat(session.getEhloResponse().isSupported(Extension.EIGHT_BIT_MIME)).isFalse();
+    assertThat(session.getEhloResponse().isSupported(Extension.STARTTLS)).isFalse();
+    assertThat(session.getEhloResponse().isSupported(Extension.SIZE)).isFalse();
+    assertThat(session.getEhloResponse().isSupported(Extension.PIPELINING)).isFalse();
 
-    assertThat(session.isAuthPlainSupported()).isFalse();
-    assertThat(session.isAuthLoginSupported()).isFalse();
+    assertThat(session.getEhloResponse().isAuthPlainSupported()).isFalse();
+    assertThat(session.getEhloResponse().isAuthLoginSupported()).isFalse();
   }
 
   @Test
@@ -174,7 +174,7 @@ public class SmtpSessionTest {
 
   @Test
   public void itThrowsIllegalStateIfPipeliningIsNotSupported() {
-    session.setSupportedExtensions(Collections.emptyList());
+    session.parseEhloResponse(Collections.emptyList());
 
     assertThatThrownBy(() -> session.sendPipelined(SMTP_CONTENT, MAIL_REQUEST, RCPT_REQUEST, DATA_REQUEST))
         .isInstanceOf(IllegalStateException.class)
@@ -246,7 +246,7 @@ public class SmtpSessionTest {
 
   @Test
   public void itWillNotAuthenticateWithAuthPlainUnlessTheServerSupportsIt() {
-    session.setSupportedExtensions(Collections.emptyList());
+    session.parseEhloResponse(Collections.emptyList());
 
     assertThatThrownBy(() -> session.authPlain("user", "password"))
         .isInstanceOf(IllegalStateException.class)
@@ -266,7 +266,7 @@ public class SmtpSessionTest {
 
   @Test
   public void itWillNotAuthenticateWithAuthLoginUnlessTheServerSupportsIt() {
-    session.setSupportedExtensions(Collections.emptyList());
+    session.parseEhloResponse(Collections.emptyList());
 
     assertThatThrownBy(() -> session.authLogin("user", "password"))
         .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
Parses the SIZE keyword of the EHLO response, and indicates if size is supported as well as the max size if that was included in the response. I also added an integration test to ensure we can send the max size with the MAIL command.

This PR also extracts EHLO parsing to its own class, and exposes the full response as a `Set<String>` for logging and detecting of extensions that aren't part of the `Extension` enum.

@axiak 