### PR TITLE
Use native TLS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
         <version>${netty41.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>1.1.33.Fork26</version>
+      </dependency>
+      <dependency>
         <groupId>org.immutables</groupId>
         <artifactId>value</artifactId>
         <version>${hubspot.immutables.version}</version>
@@ -111,6 +116,11 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- other dependencies -->

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -55,6 +55,9 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.codec.smtp.DefaultSmtpRequest;
 import io.netty.handler.codec.smtp.SmtpCommand;
 import io.netty.handler.codec.smtp.SmtpRequest;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.OpenSslEngine;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
@@ -115,6 +118,18 @@ public class IntegrationTest {
   @After
   public void after() {
     smtpServer.unbind();
+  }
+
+  @Test
+  public void itUsesNativeOpenSSL() {
+    assertThat(OpenSsl.isAvailable())
+        .withFailMessage("OpenSSL is not available").isTrue();
+
+    assertThat(SslContext.defaultClientProvider().name())
+        .withFailMessage("OpenSSL is not the default").isEqualTo("OPENSSL");
+
+    SmtpSessionConfig defaultConfig = SmtpSessionConfig.forRemoteAddress(serverAddress);
+    assertThat(defaultConfig.getSSLEngineSupplier().get()).isInstanceOf(OpenSslEngine.class);
   }
 
   @Test


### PR DESCRIPTION
Adds a dependency on boringssl, which is statically linked so doesn't require any local dependencies. Alternatively we could use OpenSSL but it's hard to install on macOS and requires a version of libapr that conflicts with Apple's.

I'm using the netty-tcnative-boringssl uberjar with native binaries for Linux, macOS and Windows. There's also a platform-specific version which is 948K instead of 2.5MB. 

Details on the various native TLS options are at http://netty.io/wiki/forked-tomcat-native.html.

@axiak 