### PR TITLE
Support chunking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <hubspot.immutables.version>2.2.10</hubspot.immutables.version>
     <netty41.version>4.1.8.Final</netty41.version>
     <james.protocols.version>1.6.3</james.protocols.version>
+    <james.netty.version>3.3.1.Final</james.netty.version>
   </properties>
 
   <dependencyManagement>
@@ -86,6 +87,11 @@
         <groupId>org.apache.james.protocols</groupId>
         <artifactId>protocols-smtp</artifactId>
         <version>${james.protocols.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty</artifactId>
+        <version>${james.netty.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -166,6 +172,11 @@
     <dependency>
       <groupId>org.apache.james.protocols</groupId>
       <artifactId>protocols-smtp</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/hubspot/smtp/client/Extension.java
+++ b/src/main/java/com/hubspot/smtp/client/Extension.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 public enum Extension {
   AUTH("auth"),
+  CHUNKING("chunking"),
   DSN("dsn"),
   EIGHT_BIT_MIME("8bitmime"),
   ENHANCEDSTATUSCODES("enhancedstatuscodes"),

--- a/src/test/java/com/hubspot/smtp/ChunkingExtension.java
+++ b/src/test/java/com/hubspot/smtp/ChunkingExtension.java
@@ -1,0 +1,174 @@
+package com.hubspot.smtp;
+
+import static com.hubspot.smtp.ExtensibleNettyServer.NETTY_CHANNEL;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.james.protocols.api.ProtocolSession;
+import org.apache.james.protocols.api.ProtocolSession.State;
+import org.apache.james.protocols.api.Request;
+import org.apache.james.protocols.api.Response;
+import org.apache.james.protocols.api.future.FutureResponseImpl;
+import org.apache.james.protocols.api.handler.CommandHandler;
+import org.apache.james.protocols.api.handler.ExtensibleHandler;
+import org.apache.james.protocols.api.handler.LineHandler;
+import org.apache.james.protocols.api.handler.WiringException;
+import org.apache.james.protocols.netty.HandlerConstants;
+import org.apache.james.protocols.smtp.MailAddress;
+import org.apache.james.protocols.smtp.MailEnvelopeImpl;
+import org.apache.james.protocols.smtp.SMTPResponse;
+import org.apache.james.protocols.smtp.SMTPRetCode;
+import org.apache.james.protocols.smtp.SMTPSession;
+import org.apache.james.protocols.smtp.core.esmtp.EhloExtension;
+import org.apache.james.protocols.smtp.dsn.DSNStatus;
+import org.apache.james.protocols.smtp.hook.Hook;
+import org.apache.james.protocols.smtp.hook.MessageHook;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+
+import com.google.common.collect.Lists;
+
+public class ChunkingExtension implements EhloExtension, CommandHandler<SMTPSession>, ExtensibleHandler, Hook {
+  private static final String MAIL_ENVELOPE = "mail envelope";
+  private static final String BDAT_HANDLER_NAME = "BDAT handler";
+  private static final Pattern BDAT_COMMAND_PATTERN = Pattern.compile("(?<size>[0-9]+)(?<last> LAST)?");
+
+  private static final Response DELIVERY_SYNTAX = new SMTPResponse(SMTPRetCode.SYNTAX_ERROR_ARGUMENTS,
+      DSNStatus.getStatus(DSNStatus.PERMANENT, DSNStatus.DELIVERY_SYNTAX) + " Invalid syntax").immutable();
+
+  private List<MessageHook> messageHandlers;
+
+  @Override
+  public Response onCommand(SMTPSession session, Request request) {
+    Matcher matcher = BDAT_COMMAND_PATTERN.matcher(request.getArgument());
+    if (!matcher.matches()) {
+      return DELIVERY_SYNTAX;
+    }
+
+    Channel channel = (Channel) session.getAttachment(NETTY_CHANNEL, State.Connection);
+    if (channel == null) {
+      throw new RuntimeException("ExtensibleNettyServer must be used to support chunking");
+    }
+
+    BdatHandler bdatHandler = new BdatHandler(channel.getPipeline(), session);
+    bdatHandler.startCapturingData(Integer.parseInt(matcher.group("size")), !matcher.group("last").isEmpty());
+    return bdatHandler.bdatResponseFuture;
+  }
+
+  @Override
+  public Collection<String> getImplCommands() {
+    return Collections.singletonList("BDAT");
+  }
+
+  @Override
+  public List<String> getImplementedEsmtpFeatures(SMTPSession session) {
+    return Lists.newArrayList("CHUNKING");
+  }
+
+  @Override
+  public List<Class<?>> getMarkerInterfaces() {
+    return Lists.newArrayList(MessageHook.class, LineHandler.class);
+  }
+
+  @Override
+  public void wireExtensions(Class<?> interfaceName, List<?> extension) throws WiringException {
+    // Save MessageHooks so we can tell them about mails we receive
+    if (MessageHook.class.equals(interfaceName)) {
+      messageHandlers = Lists.newArrayList();
+      for (Object ext : extension) {
+        if (ext instanceof MessageHook) {
+          messageHandlers.add((MessageHook) ext);
+        }
+      }
+    }
+  }
+
+  private class BdatHandler extends SimpleChannelUpstreamHandler {
+    private final ChannelPipeline pipeline;
+    private final SMTPSession session;
+    private final FutureResponseImpl bdatResponseFuture;
+
+    private int currentChunkSize;
+    private int bytesRead;
+    private boolean isLastChunk;
+
+    public BdatHandler(ChannelPipeline pipeline, SMTPSession session) {
+      this.pipeline = pipeline;
+      this.session = session;
+      this.bdatResponseFuture = new FutureResponseImpl();
+    }
+
+    @Override
+    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+      if (e.getMessage() instanceof ChannelBuffer) {
+        ChannelBuffer buffer = (ChannelBuffer) e.getMessage();
+
+        int bytesToRead = Math.min(currentChunkSize - bytesRead, buffer.readableBytes());
+        buffer.readBytes(getMailEnvelope().getMessageOutputStream(), bytesToRead);
+        bytesRead += bytesToRead;
+
+        if (bytesRead == currentChunkSize) {
+          stopCapturingData();
+        }
+
+        return;
+      }
+
+      super.messageReceived(ctx, e);
+    }
+
+    private void startCapturingData(int bytesToCapture, boolean last) {
+      currentChunkSize = bytesToCapture;
+      isLastChunk = last;
+
+      pipeline.addBefore(HandlerConstants.FRAMER, BDAT_HANDLER_NAME, this);
+
+      MailEnvelopeImpl env = new MailEnvelopeImpl();
+      env.setRecipients(Lists.newArrayList((Collection<MailAddress>) session.getAttachment(SMTPSession.RCPT_LIST, State.Transaction)));
+      env.setSender((MailAddress) session.getAttachment(SMTPSession.SENDER,ProtocolSession.State.Transaction));
+
+      session.setAttachment(MAIL_ENVELOPE, env,ProtocolSession.State.Transaction);
+    }
+
+    private void stopCapturingData() {
+      pipeline.remove(this);
+      bdatResponseFuture.setResponse(new SMTPResponse("250", String.format("Message OK, %d octets received", currentChunkSize)));
+
+      if (isLastChunk) {
+        callMessageHooks();
+      }
+    }
+
+    private void callMessageHooks() {
+      MailEnvelopeImpl env = getMailEnvelope();
+
+      try {
+        OutputStream messageOutputStream = env.getMessageOutputStream();
+
+        messageOutputStream.flush();
+        messageOutputStream.close();
+
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+
+      for (MessageHook hook : messageHandlers) {
+        hook.onMessage(session, env);
+      }
+    }
+
+    private MailEnvelopeImpl getMailEnvelope() {
+      return (MailEnvelopeImpl) session.getAttachment(MAIL_ENVELOPE, State.Transaction);
+    }
+  }
+}

--- a/src/test/java/com/hubspot/smtp/ExtensibleNettyServer.java
+++ b/src/test/java/com/hubspot/smtp/ExtensibleNettyServer.java
@@ -1,0 +1,33 @@
+package com.hubspot.smtp;
+
+import org.apache.james.protocols.api.Encryption;
+import org.apache.james.protocols.api.Protocol;
+import org.apache.james.protocols.api.ProtocolSession;
+import org.apache.james.protocols.api.ProtocolSession.State;
+import org.apache.james.protocols.netty.BasicChannelUpstreamHandler;
+import org.apache.james.protocols.netty.NettyServer;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelUpstreamHandler;
+
+public class ExtensibleNettyServer extends NettyServer {
+  static final String NETTY_CHANNEL = "netty channel";
+
+  public ExtensibleNettyServer(Protocol protocol, Encryption secure) {
+    super(protocol, secure);
+  }
+
+  protected ChannelUpstreamHandler createCoreHandler() {
+    // Supporting chunking is difficult because James offers a line-oriented interface.
+    // By saving the Netty channel into James' SMTPSession, we can add a Netty handler
+    // that can intercept the BDAT message body before James attempts to parse it
+    // into a series of lines.
+    return new BasicChannelUpstreamHandler(protocol, secure) {
+      @Override
+      protected ProtocolSession createSession(ChannelHandlerContext ctx) throws Exception {
+        ProtocolSession session = super.createSession(ctx);
+        session.setAttachment(NETTY_CHANNEL, ctx.getChannel(), State.Connection);
+        return session;
+      }
+    };
+  }
+}

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -67,6 +67,12 @@ public class EhloResponseTest {
   }
 
   @Test
+  public void itParsesChunking() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "CHUNKING");
+    assertThat(response.isSupported(Extension.CHUNKING)).isTrue();
+  }
+
+  @Test
   public void itParsesAuth() {
     EhloResponse response = parse("smtp.example.com Hello client.example.com", "AUTH PLAIN LOGIN");
     assertThat(response.isAuthPlainSupported()).isTrue();


### PR DESCRIPTION
Adds support for [SMTP chunking](https://tools.ietf.org/html/rfc3030), supported by large inbox providers like Gmail, Outlook.com and iCloud.com.

Chunking makes sending emails more efficient because they don't need to be dot-stuffed and can contain 8 bit data. However, sessions that use chunking no longer delimit requests with CRLF, which makes supporting it harder. I've added a basic extension to James to support chunking so we could have an integration test, but it requires a subclass of its `NettyServer` class to make the Netty channel available.

The new interface on `SmtpSession` is a single method called `sendChunk`. I'll likely refine this as I implement https://github.com/HubSpot/NioSmtpClient/issues/19.