### PR TITLE
Send messages efficiently

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -3,6 +3,7 @@ package com.hubspot.smtp.client;
 import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.time.Duration;
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
@@ -35,6 +36,11 @@ abstract class AbstractSmtpSessionConfig {
   @Default
   public Duration getReadTimeout() {
     return Duration.ofMinutes(2);
+  }
+
+  @Default
+  public EnumSet<Extension> getDisabledExtensions() {
+    return EnumSet.noneOf(Extension.class);
   }
 
   @Default

--- a/src/main/java/com/hubspot/smtp/client/EhloResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/EhloResponse.java
@@ -23,17 +23,29 @@ public class EhloResponse {
   private boolean isAuthPlainSupported;
   private boolean isAuthLoginSupported;
 
+
   public static EhloResponse parse(Iterable<CharSequence> lines) {
-    return new EhloResponse(lines);
+    return parse(lines, EnumSet.noneOf(Extension.class));
   }
 
-  private EhloResponse(Iterable<CharSequence> lines) {
+  public static EhloResponse parse(Iterable<CharSequence> lines, EnumSet<Extension> disabledExtensions) {
+    return new EhloResponse(lines, disabledExtensions);
+  }
+
+  private EhloResponse(Iterable<CharSequence> lines, EnumSet<Extension> disabledExtensions) {
     extensions = EnumSet.noneOf(Extension.class);
 
     for (CharSequence line : lines) {
       List<String> parts = WHITESPACE_SPLITTER.splitToList(line);
 
-      Extension.find(parts.get(0)).ifPresent(extensions::add);
+      Optional<Extension> ext = Extension.find(parts.get(0));
+      if (ext.isPresent()) {
+        if (disabledExtensions.contains(ext.get())) {
+          continue;
+        }
+
+        extensions.add(ext.get());
+      }
 
       switch (parts.get(0).toLowerCase()) {
         case "auth":

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -14,12 +14,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ObjectArrays;
@@ -66,7 +66,7 @@ public class SmtpSession {
       SmtpCommand.QUIT,
       SmtpCommand.NOOP);
 
-  private static final Supplier<Executor> SHARED_DEFAULT_EXECUTOR = () -> Suppliers.memoize(SmtpSession::getSharedExecutor).get();
+  private static final Supplier<Executor> SHARED_DEFAULT_EXECUTOR = Suppliers.memoize(SmtpSession::getSharedExecutor);
 
   private static ExecutorService getSharedExecutor() {
     ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat("niosmtpclient-%d").build();

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -273,11 +273,7 @@ public class SmtpSession {
   }
 
   private void writeContent(MessageContent content) {
-    if (ehloResponse.isSupported(Extension.EIGHT_BIT_MIME)) {
-      write(content.get8BitMimeEncodedContent());
-    } else {
-      write(content.get7BitEncodedContent());
-    }
+    write(content.getDotStuffedContent());
 
     // SmtpRequestEncoder requires that we send an SmtpContent instance after the DATA command
     // to unset its contentExpected state.

--- a/src/main/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStream.java
@@ -1,0 +1,38 @@
+package com.hubspot.smtp.messages;
+
+import java.io.InputStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.stream.ChunkedStream;
+
+class CrlfTerminatingChunkedStream extends ChunkedStream {
+  private static final byte CR = '\r';
+  private static final byte LF = '\n';
+  private static final int DEFAULT_CHUNK_SIZE = 8192;
+  private static final byte[] TRAILING_BYTES = { CR, LF };
+
+  CrlfTerminatingChunkedStream(InputStream in) {
+    this(in, DEFAULT_CHUNK_SIZE);
+  }
+
+  CrlfTerminatingChunkedStream(InputStream in, int chunkSize) {
+    super(in, chunkSize);
+  }
+
+  @Override
+  public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
+    ByteBuf chunk = super.readChunk(allocator);
+
+    int length = chunk.readableBytes();
+    if (!isEndOfInput()) {
+      return chunk;
+    }
+
+    if (length >= 2 && chunk.getByte(length - 2) == CR && chunk.getByte(length - 1) == LF) {
+      return chunk;
+    }
+
+    return allocator.compositeBuffer(2).addComponents(true, chunk, allocator.buffer(2).writeBytes(TRAILING_BYTES));
+  }
+}

--- a/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
@@ -2,17 +2,26 @@ package com.hubspot.smtp.messages;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 
 import com.google.common.io.ByteSource;
+import com.google.common.io.CharStreams;
 
 public class InputStreamMessageContent extends MessageContent {
-  private final Supplier<InputStream> stream;
+  private static final int UNCOUNTED = -1;
+  private static final int READ_LIMIT = 8192;
+
+  private final Supplier<InputStream> streamSupplier;
   private final int size;
   private final MessageContentEncoding encoding;
 
-  public InputStreamMessageContent(Supplier<InputStream> stream, int size, MessageContentEncoding encoding) {
-    this.stream = stream;
+  private int eightBitCharCount = UNCOUNTED;
+  private InputStream stream;
+
+  public InputStreamMessageContent(Supplier<InputStream> streamSupplier, int size, MessageContentEncoding encoding) {
+    this.streamSupplier = streamSupplier;
     this.size = size;
     this.encoding = encoding;
   }
@@ -28,19 +37,72 @@ public class InputStreamMessageContent extends MessageContent {
 
   @Override
   public Object getContent() {
-    return new CrlfTerminatingChunkedStream(stream.get());
+    return new CrlfTerminatingChunkedStream(getStream());
   }
 
   @Override
   public Object getDotStuffedContent() {
     // note: size is hard to predict for dot-stuffed content as
     // the transformation might add a few extra bytes
-    return new DotStuffingChunkedStream(stream.get(), size);
+    return new DotStuffingChunkedStream(getStream(), size);
   }
 
   @Override
   public MessageContentEncoding getEncoding() {
     return encoding;
+  }
+
+  @Override
+  public int count8bitCharacters() {
+    if (eightBitCharCount != UNCOUNTED) {
+      return eightBitCharCount;
+    }
+
+    eightBitCharCount = 0;
+
+    InputStream inputStream = getStream();
+    inputStream.mark(READ_LIMIT);
+
+    try {
+      int c, bytesRead = 0;
+
+      while (bytesRead < READ_LIMIT && (c = inputStream.read()) != -1) {
+        if (0 != (c & 0x80)) {
+          eightBitCharCount++;
+        }
+
+        bytesRead++;
+      }
+
+      // if we've already read READ_LIMIT, estimate the remaining stream
+      if (bytesRead == READ_LIMIT) {
+        eightBitCharCount *= size / READ_LIMIT;
+      }
+
+      inputStream.reset();
+
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return eightBitCharCount;
+  }
+
+  @Override
+  public String getContentAsString() {
+    try {
+      return CharStreams.toString(new InputStreamReader(getStream(), StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private InputStream getStream() {
+    if (stream == null) {
+      stream = streamSupplier.get();
+    }
+
+    return stream;
   }
 
   private static Supplier<InputStream> getStream(ByteSource byteSource) {

--- a/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/InputStreamMessageContent.java
@@ -6,8 +6,6 @@ import java.util.function.Supplier;
 
 import com.google.common.io.ByteSource;
 
-import io.netty.handler.stream.ChunkedStream;
-
 public class InputStreamMessageContent extends MessageContent {
   private final Supplier<InputStream> stream;
   private final int size;
@@ -30,7 +28,7 @@ public class InputStreamMessageContent extends MessageContent {
 
   @Override
   public Object getContent() {
-    return new ChunkedStream(stream.get());
+    return new CrlfTerminatingChunkedStream(stream.get());
   }
 
   @Override

--- a/src/main/java/com/hubspot/smtp/messages/MessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContent.java
@@ -42,4 +42,8 @@ public abstract class MessageContent {
   public abstract Object getDotStuffedContent();
 
   public abstract MessageContentEncoding getEncoding();
+
+  public abstract int count8bitCharacters();
+
+  public abstract String getContentAsString();
 }

--- a/src/main/java/com/hubspot/smtp/messages/MessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContent.java
@@ -9,11 +9,23 @@ import io.netty.buffer.ByteBuf;
 
 public abstract class MessageContent {
   public static MessageContent of(ByteBuf messageBuffer) {
-    return new ByteBufMessageContent(messageBuffer, MessageContentEncoding.REQUIRES_DOT_STUFFING);
+    return of(messageBuffer, MessageContentEncoding.UNKNOWN);
+  }
+
+  public static MessageContent of(ByteBuf messageBuffer, MessageContentEncoding encoding) {
+    return new ByteBufMessageContent(messageBuffer, encoding);
+  }
+
+  public static MessageContent of(Supplier<InputStream> messageStream, int size) {
+    return of(messageStream, size, MessageContentEncoding.UNKNOWN);
   }
 
   public static MessageContent of(Supplier<InputStream> messageStream, int size, MessageContentEncoding encoding) {
     return new InputStreamMessageContent(messageStream, size, encoding);
+  }
+
+  public static MessageContent of(ByteSource byteSource, int size) {
+    return of(byteSource, size, MessageContentEncoding.UNKNOWN);
   }
 
   public static MessageContent of(ByteSource byteSource, int size, MessageContentEncoding encoding) {
@@ -22,13 +34,12 @@ public abstract class MessageContent {
 
   public abstract int size();
 
-  // only allow subclasses from this package because only certain objects can be returned from
-  // get8BitMimeEncodedContent / get7BitEncodedContent
+  // only allow subclasses from this package because only certain objects can be returned from getContent
   MessageContent() {}
 
-  public abstract Object get8BitMimeEncodedContent();
+  public abstract Object getContent();
 
-  public Object get7BitEncodedContent() {
-    return get8BitMimeEncodedContent();
-  }
+  public abstract Object getDotStuffedContent();
+
+  public abstract MessageContentEncoding getEncoding();
 }

--- a/src/main/java/com/hubspot/smtp/messages/MessageContentEncoding.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContentEncoding.java
@@ -1,6 +1,7 @@
 package com.hubspot.smtp.messages;
 
 public enum MessageContentEncoding {
-  ASSUME_DOT_STUFFED,
-  REQUIRES_DOT_STUFFING
+  SEVEN_BIT,
+  EIGHT_BIT,
+  UNKNOWN
 }

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -190,7 +190,7 @@ public class IntegrationTest {
   @Test
   public void itCanSendAnEmailUsingAStream() throws Exception {
     String messageText = repeat(repeat("0123456789", 7) + "\r\n", 10_000);
-    MessageContent messageContent = MessageContent.of(ByteSource.wrap(messageText.getBytes()), messageText.length(), MessageContentEncoding.ASSUME_DOT_STUFFED);
+    MessageContent messageContent = MessageContent.of(ByteSource.wrap(messageText.getBytes()), messageText.length(), MessageContentEncoding.SEVEN_BIT);
 
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -2,6 +2,8 @@ package com.hubspot.smtp.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.EnumSet;
+
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
@@ -31,6 +33,15 @@ public class EhloResponseTest {
 
     assertThat(response.isAuthPlainSupported()).isTrue();
     assertThat(response.isAuthLoginSupported()).isTrue();
+  }
+
+  @Test
+  public void itIgnoresDisabledExtensions() {
+    EhloResponse response = EhloResponse.parse(Lists.newArrayList("smtp.example.com Hello client.example.com", "8BITMIME", "STARTTLS"),
+        EnumSet.of(Extension.EIGHT_BIT_MIME));
+
+    assertThat(response.isSupported(Extension.EIGHT_BIT_MIME)).isFalse();
+    assertThat(response.isSupported(Extension.STARTTLS)).isTrue();
   }
 
   @Test

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.io.ByteSource;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.hubspot.smtp.messages.MessageContent;
-import com.hubspot.smtp.messages.MessageContentEncoding;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -97,7 +96,7 @@ public class SmtpSessionTest {
   public void itSendsContents() {
     session.send(SMTP_CONTENT);
 
-    verify(channel).write(SMTP_CONTENT.get7BitEncodedContent());
+    verify(channel).write(SMTP_CONTENT.getDotStuffedContent());
     verify(channel).write(EMPTY_LAST_CONTENT);
     verify(channel).flush();
   }
@@ -106,7 +105,7 @@ public class SmtpSessionTest {
   public void itThrowsIllegalArgumentIfTheSubmittedMessageSizeIsLargerThanTheMaximum() {
     session.parseEhloResponse(Lists.newArrayList("SIZE 1024"));
 
-    MessageContent largeMessage = MessageContent.of(ByteSource.wrap(new byte[0]), 1025, MessageContentEncoding.ASSUME_DOT_STUFFED);
+    MessageContent largeMessage = MessageContent.of(ByteSource.wrap(new byte[0]), 1025);
 
     assertThatThrownBy(() -> session.send(largeMessage))
       .isInstanceOf(MessageTooLargeException.class)
@@ -203,7 +202,7 @@ public class SmtpSessionTest {
     session.sendPipelined(SMTP_CONTENT, MAIL_REQUEST, RCPT_REQUEST, DATA_REQUEST);
 
     InOrder order = inOrder(channel);
-    order.verify(channel).write(SMTP_CONTENT.get7BitEncodedContent());
+    order.verify(channel).write(SMTP_CONTENT.getDotStuffedContent());
     order.verify(channel).write(EMPTY_LAST_CONTENT);
     order.verify(channel).write(MAIL_REQUEST);
     order.verify(channel).write(RCPT_REQUEST);

--- a/src/test/java/com/hubspot/smtp/messages/ByteBufMessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/ByteBufMessageContentTest.java
@@ -13,31 +13,31 @@ import io.netty.util.CharsetUtil;
 public class ByteBufMessageContentTest {
   @Test
   public void itPerformsDotStuffingIfRequired() {
-    ByteBufMessageContent content = createContent(".abc", MessageContentEncoding.REQUIRES_DOT_STUFFING);
-    assertThat(extract(content.get8BitMimeEncodedContent())).isEqualTo("..abc\r\n");
+    ByteBufMessageContent content = createContent(".abc");
+    assertThat(extract(content.getDotStuffedContent())).isEqualTo("..abc\r\n");
   }
 
   @Test
   public void itDoesNotPerformDotStuffingIfNotRequired() {
-    ByteBufMessageContent content = createContent(".abc", MessageContentEncoding.ASSUME_DOT_STUFFED);
-    assertThat(extract(content.get8BitMimeEncodedContent())).isEqualTo(".abc\r\n");
+    ByteBufMessageContent content = createContent(".abc");
+    assertThat(extract(content.getContent())).isEqualTo(".abc\r\n");
   }
 
   @Test
   public void itAddsTerminationIfRequired() {
-    ByteBufMessageContent content = createContent("abc", MessageContentEncoding.REQUIRES_DOT_STUFFING);
-    assertThat(extract(content.get8BitMimeEncodedContent())).isEqualTo("abc\r\n");
+    ByteBufMessageContent content = createContent("abc");
+    assertThat(extract(content.getContent())).isEqualTo("abc\r\n");
   }
 
   @Test
   public void itDoesNotAddTerminationIfAlreadyPresent() {
-    ByteBufMessageContent content = createContent("abc\r\n", MessageContentEncoding.REQUIRES_DOT_STUFFING);
-    assertThat(extract(content.get8BitMimeEncodedContent())).isEqualTo("abc\r\n");
+    ByteBufMessageContent content = createContent("abc\r\n");
+    assertThat(extract(content.getContent())).isEqualTo("abc\r\n");
   }
 
-  private ByteBufMessageContent createContent(String testString, MessageContentEncoding encoding) {
+  private ByteBufMessageContent createContent(String testString) {
     ByteBuf sourceBuffer = Unpooled.wrappedBuffer(testString.getBytes(StandardCharsets.UTF_8));
-    return new ByteBufMessageContent(sourceBuffer, encoding);
+    return new ByteBufMessageContent(sourceBuffer, MessageContentEncoding.UNKNOWN);
   }
 
   private String extract(Object o) {

--- a/src/test/java/com/hubspot/smtp/messages/ByteBufMessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/ByteBufMessageContentTest.java
@@ -10,7 +10,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 
-public class ByteBufMessageContentTest {
+public class ByteBufMessageContentTest extends MessageContentTest {
   @Test
   public void itPerformsDotStuffingIfRequired() {
     ByteBufMessageContent content = createContent(".abc");
@@ -38,6 +38,11 @@ public class ByteBufMessageContentTest {
   private ByteBufMessageContent createContent(String testString) {
     ByteBuf sourceBuffer = Unpooled.wrappedBuffer(testString.getBytes(StandardCharsets.UTF_8));
     return new ByteBufMessageContent(sourceBuffer, MessageContentEncoding.UNKNOWN);
+  }
+
+  @Override
+  protected ByteBufMessageContent createContent(byte[] bytes) {
+    return new ByteBufMessageContent(Unpooled.wrappedBuffer(bytes), MessageContentEncoding.UNKNOWN);
   }
 
   private String extract(Object o) {

--- a/src/test/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStreamTest.java
@@ -1,0 +1,54 @@
+package com.hubspot.smtp.messages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.CharsetUtil;
+
+public class CrlfTerminatingChunkedStreamTest {
+  private static final String CRLF = "\r\n";
+  private static final UnpooledByteBufAllocator ALLOCATOR = new UnpooledByteBufAllocator(true);
+
+  @Test
+  public void itTerminatesWithCrlf() throws Exception {
+    // adds
+    assertThat(terminate(".")).isEqualTo("." + CRLF);
+    assertThat(terminate("abc")).isEqualTo("abc" + CRLF);
+    assertThat(terminate("\r\ndef")).isEqualTo("\r\ndef" + CRLF);
+    assertThat(terminate("abc\n")).isEqualTo("abc\n" + CRLF);
+    assertThat(terminate("abc\r")).isEqualTo("abc\r" + CRLF);
+
+    // does not add
+    assertThat(terminate("\r\n")).isEqualTo("\r\n");
+    assertThat(terminate("abc\r\n")).isEqualTo("abc\r\n");
+  }
+
+  @Test
+  public void itOnlyTerminatesTheFinalChunk() throws Exception {
+    assertThat(terminate("0123456789", 3)).isEqualTo("0123456789" + CRLF);
+  }
+
+  private String terminate(String testString) throws Exception {
+    return terminate(testString, 8192);
+  }
+
+  private String terminate(String testString, int chunkSize) throws Exception {
+    ByteArrayInputStream stream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8));
+    CrlfTerminatingChunkedStream chunkedStream = new CrlfTerminatingChunkedStream(stream, chunkSize);
+
+    CompositeByteBuf destBuffer = ALLOCATOR.compositeBuffer();
+    while (!chunkedStream.isEndOfInput()) {
+      destBuffer.addComponent(true, chunkedStream.readChunk(ALLOCATOR).retain());
+    }
+
+    byte[] bytes = new byte[destBuffer.readableBytes()];
+    destBuffer.getBytes(0, bytes);
+    return new String(bytes, CharsetUtil.UTF_8);
+  }
+}

--- a/src/test/java/com/hubspot/smtp/messages/InputStreamMessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/InputStreamMessageContentTest.java
@@ -1,0 +1,10 @@
+package com.hubspot.smtp.messages;
+
+import com.google.common.io.ByteSource;
+
+public class InputStreamMessageContentTest extends MessageContentTest {
+  @Override
+  protected MessageContent createContent(byte[] bytes) {
+    return new InputStreamMessageContent(ByteSource.wrap(bytes), bytes.length, MessageContentEncoding.UNKNOWN);
+  }
+}

--- a/src/test/java/com/hubspot/smtp/messages/MessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/MessageContentTest.java
@@ -1,0 +1,33 @@
+package com.hubspot.smtp.messages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public abstract class MessageContentTest {
+  @Test
+  public void itCounts8BitCharacters() {
+    byte[] allZeros = new byte[] {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00
+    };
+
+    assertThat(createContent(allZeros).count8bitCharacters()).isEqualTo(0);
+
+    byte[] allHighBit = new byte[] {
+        (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80,
+        (byte) 0x80, (byte) 0x80
+    };
+
+    assertThat(createContent(allHighBit).count8bitCharacters()).isEqualTo(allHighBit.length);
+
+    byte[] mixed = new byte[] {
+        (byte) 0x80, (byte) 0x00, (byte) 0x80, (byte) 0x00, (byte) 0x80, (byte) 0x00, (byte) 0x80, (byte) 0x00,
+        (byte) 0x80, (byte) 0x00
+    };
+
+    assertThat(createContent(mixed).count8bitCharacters()).isEqualTo(mixed.length / 2);
+  }
+
+  protected abstract MessageContent createContent(byte[] bytes);
+}


### PR DESCRIPTION
Adds a facade `send(from, to, content)` that sends emails using the most efficient ESTMP extensions as described in https://github.com/HubSpot/NioSmtpClient/issues/19, and adds `RSET` for you if necessary.

Depending on server support and the provided `MessageContent`, `send` might use:

* Pipelining
* Chunking
* 8bitmime

It will automatically dot-stuff messages for you if chunking isn't supported.

A new property on `MessageContent` can describe the message as 7 bit, 8 bit or unknown and the facade uses this to determine the right method to send the message. Messages marked as unknown are sent via chunking or 8bitmime if possible, falling back to an efficient test of the email to see if it contains 8 bit characters.

This PR does not include support for dynamically rewriting 8 bit messages to quoted-printable or base64. I'll add that in a future PR.

Fixes https://github.com/HubSpot/NioSmtpClient/issues/19

@axiak 