### PR TITLE
Correct casing of SslEngineSupplier

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -54,7 +54,7 @@ abstract class AbstractSmtpSessionConfig {
   }
 
   @Default
-  public Supplier<SSLEngine> getSSLEngineSupplier() {
+  public Supplier<SSLEngine> getSslEngineSupplier() {
     return this::createSSLEngine;
   }
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -129,7 +129,7 @@ public class SmtpSession {
   private CompletionStage<SmtpClientResponse> performTlsHandshake(SmtpClientResponse r) {
     CompletableFuture<SmtpClientResponse> ourFuture = new CompletableFuture<>();
 
-    SslHandler sslHandler = new SslHandler(config.getSSLEngineSupplier().get());
+    SslHandler sslHandler = new SslHandler(config.getSslEngineSupplier().get());
     channel.pipeline().addFirst(sslHandler);
 
     sslHandler.handshakeFuture().addListener(nettyFuture -> {

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -399,7 +399,7 @@ public class IntegrationTest {
   }
 
   private SmtpSessionConfig getDefaultConfig() {
-    return SmtpSessionConfig.forRemoteAddress(serverAddress).withSSLEngineSupplier(this::createInsecureSSLEngine);
+    return SmtpSessionConfig.forRemoteAddress(serverAddress).withSslEngineSupplier(this::createInsecureSSLEngine);
   }
 
   private SSLEngine createInsecureSSLEngine() {

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -618,14 +618,14 @@ public class SmtpSessionTest {
   public void itDeterminesEncryptionStatusByCheckingPipeline() {
     assertThat(session.isEncrypted()).isFalse();
 
-    when(pipeline.get(SslHandler.class)).thenReturn(new SslHandler(CONFIG.getSSLEngineSupplier().get()));
+    when(pipeline.get(SslHandler.class)).thenReturn(new SslHandler(CONFIG.getSslEngineSupplier().get()));
 
     assertThat(session.isEncrypted()).isTrue();
   }
 
   @Test
   public void itThrowsWhenStartTlsIsCalledIfEncryptionIsActive() {
-    when(pipeline.get(SslHandler.class)).thenReturn(new SslHandler(CONFIG.getSSLEngineSupplier().get()));
+    when(pipeline.get(SslHandler.class)).thenReturn(new SslHandler(CONFIG.getSslEngineSupplier().get()));
 
     assertThatThrownBy(() -> session.startTls())
         .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
The type is properly called SSLEngine but the setter ends up
being called sSLEngineSupplier so this naming is nicer.