### PR TITLE
Make size optional when submitting messages

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -7,7 +7,9 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -35,6 +37,7 @@ import com.hubspot.smtp.utils.SmtpResponses;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -175,7 +178,7 @@ public class SmtpSession {
       return sendAs8BitMime(from, recipients, content);
     }
 
-    if (content.count8bitCharacters() == 0) {
+    if (content.get8bitCharacterProportion() == 0) {
       return sendAs7Bit(from, recipients, content);
     }
 
@@ -188,10 +191,15 @@ public class SmtpSession {
       List<Object> objects = Lists.newArrayListWithExpectedSize(3 + recipients.size());
       objects.add(SmtpRequests.mail(from));
       objects.addAll(rpctCommands(recipients));
-      objects.add(new DefaultSmtpRequest(BDAT_COMMAND, Integer.toString(content.size()), "LAST"));
-      objects.add(content.getContent());
 
-      return beginSequence(objects.size() - 1, objects.toArray()).toResponses();
+      Iterator<ByteBuf> chunkIterator = content.getContentChunkIterator(channel.alloc());
+
+      ByteBuf firstChunk = chunkIterator.next();
+      objects.add(getBdatRequestWithData(firstChunk, !chunkIterator.hasNext()));
+
+      return beginSequence(objects.size(), objects.toArray())
+          .thenSendInTurn(getBdatIterator(chunkIterator))
+          .toResponses();
 
     } else {
       SendSequence sequence = beginSequence(1, SmtpRequests.mail(from));
@@ -201,9 +209,33 @@ public class SmtpSession {
       }
 
       return sequence
-          .thenSend(new DefaultSmtpRequest(BDAT_COMMAND, Integer.toString(content.size()), "LAST"), content.getContent())
+          .thenSendInTurn(getBdatIterator(content.getContentChunkIterator(channel.alloc())))
           .toResponses();
     }
+  }
+
+  @SuppressFBWarnings("VA_FORMAT_STRING_USES_NEWLINE") // we shouldn't use platform-specific newlines for SMTP
+  private ByteBuf getBdatRequestWithData(ByteBuf data, boolean isLast) {
+    String request = String.format("BDAT %d%s\r\n", data.readableBytes(), isLast ? " LAST" : "");
+    ByteBuf requestBuf = channel.alloc().buffer(request.length());
+    ByteBufUtil.writeAscii(requestBuf, request);
+
+    return channel.alloc().compositeBuffer().addComponents(true, requestBuf, data);
+  }
+
+  private Iterator<Object> getBdatIterator(Iterator<ByteBuf> chunkIterator) {
+    return new Iterator<Object>() {
+      @Override
+      public boolean hasNext() {
+        return chunkIterator.hasNext();
+      }
+
+      @Override
+      public Object next() {
+        ByteBuf buf = chunkIterator.next();
+        return getBdatRequestWithData(buf, !chunkIterator.hasNext());
+      }
+    };
   }
 
   private CompletableFuture<SmtpClientResponse[]> sendAs7Bit(String from, Collection<String> recipients, MessageContent content) {
@@ -287,7 +319,7 @@ public class SmtpSession {
   public CompletableFuture<SmtpClientResponse> sendChunk(ByteBuf data, boolean isLast) {
     Preconditions.checkState(ehloResponse.isSupported(Extension.CHUNKING), "Chunking is not supported on this server");
     Preconditions.checkNotNull(data);
-    checkMessageSize(chunkedBytesSent.addAndGet(data.readableBytes()));
+    checkMessageSize(OptionalInt.of(chunkedBytesSent.addAndGet(data.readableBytes())));
 
     if (isLast) {
       // reset the counter so we can send another mail over this connection
@@ -317,7 +349,7 @@ public class SmtpSession {
     Preconditions.checkState(ehloResponse.isSupported(Extension.PIPELINING), "Pipelining is not supported on this server");
     Preconditions.checkNotNull(requests);
     checkValidPipelinedRequest(requests);
-    checkMessageSize(content == null ? 0 : content.size());
+    checkMessageSize(content == null ? OptionalInt.empty() : content.size());
 
     int expectedResponses = requests.length + (content == null ? 0 : 1);
     CompletableFuture<SmtpResponse[]> responseFuture = responseHandler.createResponseFuture(expectedResponses, () -> createDebugString(requests));
@@ -377,12 +409,12 @@ public class SmtpSession {
     return applyOnExecutor(responseFuture, loginResponse -> new SmtpClientResponse(loginResponse[0], this));
   }
 
-  private void checkMessageSize(int size) {
-    if (!ehloResponse.getMaxMessageSize().isPresent()) {
+  private void checkMessageSize(OptionalInt size) {
+    if (!ehloResponse.getMaxMessageSize().isPresent() || !size.isPresent()) {
       return;
     }
 
-    if (ehloResponse.getMaxMessageSize().get() < size) {
+    if (ehloResponse.getMaxMessageSize().get() < size.getAsInt()) {
       throw new MessageTooLargeException(config.getConnectionId(), ehloResponse.getMaxMessageSize().get());
     }
   }
@@ -476,8 +508,7 @@ public class SmtpSession {
     CompletableFuture<SmtpResponse[]> responseFuture;
 
     SendSequence(int expectedResponses, Object... objects) {
-      responseFuture = createFuture(expectedResponses, objects);
-      writeObjects(objects);
+      responseFuture = writeObjectsAndCollectResponses(expectedResponses, objects);
     }
 
     SendSequence thenSend(Object... objects) {
@@ -486,12 +517,47 @@ public class SmtpSession {
           return CompletableFuture.completedFuture(responses);
         }
 
-        CompletableFuture<SmtpResponse[]> nextFuture = createFuture(1, objects);
-        writeObjects(objects);
-        return nextFuture.thenApply(newResponses -> ObjectArrays.concat(responses, newResponses, SmtpResponse.class));
+        return writeObjectsAndCollectResponses(1, objects)
+            .thenApply(mergeResponses(responses));
       });
 
       return this;
+    }
+
+    // sends the next item from the iterator only when the response for the previous one
+    // has arrived, continuing until the iterator is empty or the response is an error
+    SendSequence thenSendInTurn(Iterator<Object> iterator) {
+      responseFuture = sendNext(responseFuture, iterator);
+      return this;
+    }
+
+    private CompletableFuture<SmtpResponse[]> sendNext(CompletableFuture<SmtpResponse[]> prevFuture, Iterator<Object> iterator) {
+      if (!iterator.hasNext()) {
+        return prevFuture;
+      }
+
+      return prevFuture.thenCompose(responses -> {
+        if (SmtpResponses.isError(responses[responses.length - 1])) {
+          return CompletableFuture.completedFuture(responses);
+        }
+
+        Object nextObject = iterator.next();
+
+        CompletableFuture<SmtpResponse[]> f = writeObjectsAndCollectResponses(1, nextObject)
+            .thenApply(mergeResponses(responses));
+
+        return sendNext(f, iterator);
+      });
+    }
+
+    private Function<SmtpResponse[], SmtpResponse[]> mergeResponses(SmtpResponse[] existingResponses) {
+      return newResponses -> ObjectArrays.concat(existingResponses, newResponses, SmtpResponse.class);
+    }
+
+    private CompletableFuture<SmtpResponse[]> writeObjectsAndCollectResponses(int expectedResponses, Object... objects) {
+      CompletableFuture<SmtpResponse[]> nextFuture = createFuture(expectedResponses, objects);
+      writeObjects(objects);
+      return nextFuture;
     }
 
     CompletableFuture<SmtpClientResponse[]> toResponses() {

--- a/src/main/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStream.java
@@ -24,15 +24,22 @@ class CrlfTerminatingChunkedStream extends ChunkedStream {
   public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
     ByteBuf chunk = super.readChunk(allocator);
 
-    int length = chunk.readableBytes();
     if (!isEndOfInput()) {
       return chunk;
     }
 
-    if (length >= 2 && chunk.getByte(length - 2) == CR && chunk.getByte(length - 1) == LF) {
+    if (isTerminatedWithCrLf(chunk)) {
       return chunk;
     }
 
     return allocator.compositeBuffer(2).addComponents(true, chunk, allocator.buffer(2).writeBytes(TRAILING_BYTES));
+  }
+
+  private boolean isTerminatedWithCrLf(ByteBuf chunk) {
+    int length = chunk.readableBytes();
+
+    return length >= 2 &&
+        chunk.getByte(length - 2) == CR &&
+        chunk.getByte(length - 1) == LF;
   }
 }

--- a/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
@@ -11,23 +11,19 @@ class DotStuffingChunkedStream extends ChunkedStream {
   private static final byte LF = '\n';
   private static final int DEFAULT_CHUNK_SIZE = 8192;
 
-  private final int size;
   private final byte[] trailingBytes = { CR, LF };
-  private int bytesRead = 0;
 
-  DotStuffingChunkedStream(InputStream in, int size) {
-    this(in, size, DEFAULT_CHUNK_SIZE);
+  DotStuffingChunkedStream(InputStream in) {
+    this(in, DEFAULT_CHUNK_SIZE);
   }
 
-  DotStuffingChunkedStream(InputStream in, int size, int chunkSize) {
+  DotStuffingChunkedStream(InputStream in, int chunkSize) {
     super(in, chunkSize);
-    this.size = size;
   }
 
   @Override
   public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
     ByteBuf chunk = super.readChunk(allocator);
-    bytesRead += chunk.readableBytes();
 
     byte[] prevChunkTrailingBytes = new byte[2];
     prevChunkTrailingBytes[0] = trailingBytes[0];
@@ -35,8 +31,7 @@ class DotStuffingChunkedStream extends ChunkedStream {
 
     updateTrailingBytes(chunk);
 
-    boolean isLastChunk = bytesRead >= size;
-    boolean appendCRLF = isLastChunk && !(trailingBytes[0] == CR && trailingBytes[1] == LF);
+    boolean appendCRLF = isEndOfInput() && !(trailingBytes[0] == CR && trailingBytes[1] == LF);
 
     return DotStuffing.createDotStuffedBuffer(allocator, chunk, prevChunkTrailingBytes,
         appendCRLF ? MessageTermination.ADD_CRLF : MessageTermination.DO_NOT_TERMINATE);

--- a/src/main/java/com/hubspot/smtp/messages/MessageContent.java
+++ b/src/main/java/com/hubspot/smtp/messages/MessageContent.java
@@ -1,11 +1,14 @@
 package com.hubspot.smtp.messages;
 
 import java.io.InputStream;
+import java.util.Iterator;
+import java.util.OptionalInt;
 import java.util.function.Supplier;
 
 import com.google.common.io.ByteSource;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 
 public abstract class MessageContent {
   public static MessageContent of(ByteBuf messageBuffer) {
@@ -16,34 +19,41 @@ public abstract class MessageContent {
     return new ByteBufMessageContent(messageBuffer, encoding);
   }
 
-  public static MessageContent of(Supplier<InputStream> messageStream, int size) {
-    return of(messageStream, size, MessageContentEncoding.UNKNOWN);
+  public static MessageContent of(Supplier<InputStream> messageStream) {
+    return of(messageStream, MessageContentEncoding.UNKNOWN);
   }
 
-  public static MessageContent of(Supplier<InputStream> messageStream, int size, MessageContentEncoding encoding) {
-    return new InputStreamMessageContent(messageStream, size, encoding);
+  public static MessageContent of(Supplier<InputStream> messageStream, MessageContentEncoding encoding) {
+    return new InputStreamMessageContent(messageStream, OptionalInt.empty(), encoding);
   }
 
-  public static MessageContent of(ByteSource byteSource, int size) {
-    return of(byteSource, size, MessageContentEncoding.UNKNOWN);
+  public static MessageContent of(Supplier<InputStream> messageStream, MessageContentEncoding encoding, int size) {
+    return new InputStreamMessageContent(messageStream, OptionalInt.of(size), encoding);
   }
 
-  public static MessageContent of(ByteSource byteSource, int size, MessageContentEncoding encoding) {
+  public static MessageContent of(ByteSource byteSource) {
+    return of(byteSource, MessageContentEncoding.UNKNOWN);
+  }
+
+  public static MessageContent of(ByteSource byteSource, MessageContentEncoding encoding) {
+    OptionalInt size = byteSource.sizeIfKnown().transform(s -> OptionalInt.of(Math.toIntExact(s))).or(OptionalInt.empty());
     return new InputStreamMessageContent(byteSource, size, encoding);
   }
 
-  public abstract int size();
+  public abstract OptionalInt size();
 
   // only allow subclasses from this package because only certain objects can be returned from getContent
   MessageContent() {}
 
   public abstract Object getContent();
 
+  public abstract Iterator<ByteBuf> getContentChunkIterator(ByteBufAllocator allocator);
+
   public abstract Object getDotStuffedContent();
 
   public abstract MessageContentEncoding getEncoding();
 
-  public abstract int count8bitCharacters();
+  public abstract float get8bitCharacterProportion();
 
   public abstract String getContentAsString();
 }

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -274,7 +274,7 @@ public class IntegrationTest {
   @Test
   public void itCanSendAnEmailUsingAStream() throws Exception {
     String messageText = repeat(repeat("0123456789", 7) + "\r\n", 10_000);
-    MessageContent messageContent = MessageContent.of(ByteSource.wrap(messageText.getBytes()), messageText.length(), MessageContentEncoding.SEVEN_BIT);
+    MessageContent messageContent = MessageContent.of(ByteSource.wrap(messageText.getBytes()), MessageContentEncoding.SEVEN_BIT);
 
     connect()
         .thenCompose(r -> assertSuccess(r).send(req(EHLO, "hubspot.com")))

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
@@ -48,7 +48,7 @@ public class DotStuffingChunkedStreamTest {
 
   private String dotStuff(String testString, int chunkSize) throws Exception {
     ByteArrayInputStream stream = new ByteArrayInputStream(testString.getBytes(StandardCharsets.UTF_8));
-    DotStuffingChunkedStream chunkedStream = new DotStuffingChunkedStream(stream, testString.length(), chunkSize);
+    DotStuffingChunkedStream chunkedStream = new DotStuffingChunkedStream(stream, chunkSize);
 
     CompositeByteBuf destBuffer = ALLOCATOR.compositeBuffer();
     while (!chunkedStream.isEndOfInput()) {

--- a/src/test/java/com/hubspot/smtp/messages/InputStreamMessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/InputStreamMessageContentTest.java
@@ -1,10 +1,12 @@
 package com.hubspot.smtp.messages;
 
+import java.util.OptionalInt;
+
 import com.google.common.io.ByteSource;
 
 public class InputStreamMessageContentTest extends MessageContentTest {
   @Override
   protected MessageContent createContent(byte[] bytes) {
-    return new InputStreamMessageContent(ByteSource.wrap(bytes), bytes.length, MessageContentEncoding.UNKNOWN);
+    return new InputStreamMessageContent(ByteSource.wrap(bytes), OptionalInt.of(bytes.length), MessageContentEncoding.UNKNOWN);
   }
 }

--- a/src/test/java/com/hubspot/smtp/messages/MessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/MessageContentTest.java
@@ -12,21 +12,21 @@ public abstract class MessageContentTest {
         0x00, 0x00
     };
 
-    assertThat(createContent(allZeros).count8bitCharacters()).isEqualTo(0);
+    assertThat(createContent(allZeros).get8bitCharacterProportion()).isEqualTo(0.0F);
 
     byte[] allHighBit = new byte[] {
         (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80,
         (byte) 0x80, (byte) 0x80
     };
 
-    assertThat(createContent(allHighBit).count8bitCharacters()).isEqualTo(allHighBit.length);
+    assertThat(createContent(allHighBit).get8bitCharacterProportion()).isEqualTo(1.0F);
 
     byte[] mixed = new byte[] {
         (byte) 0x80, (byte) 0x00, (byte) 0x80, (byte) 0x00, (byte) 0x80, (byte) 0x00, (byte) 0x80, (byte) 0x00,
         (byte) 0x80, (byte) 0x00
     };
 
-    assertThat(createContent(mixed).count8bitCharacters()).isEqualTo(mixed.length / 2);
+    assertThat(createContent(mixed).get8bitCharacterProportion()).isEqualTo(0.5F);
   }
 
   protected abstract MessageContent createContent(byte[] bytes);


### PR DESCRIPTION
It can be convenient to submit messages based on an `InputStream` without knowing the full size of the stream. Unfortunately though, we rely on knowing the message size in three places:

* to support the ESMTP message size extension (rejecting messages that are over the permitted size)
* to estimate the number of 8 bit characters so we can re-encode messages as quoted-printable or base64 as necessary (in fact re-encoding isn't yet supported)
* to send `BDAT` message chunks

This PR makes the `size` property of `MessageContent` an `OptionalInt` and accommodates the above features as follows:

* we don't check the size of messages where `MessageContent::size` is `OptionalInt.empty()`
* we return a proportion of 8 bit characters (1.0 = all 8 bit; 0.0 = all 7 bit) instead of a count 
* we make use of `ChunkedInput` chunking to read chunks (currently 8K in size), transforming them to `BDAT` requests on demand.

For `BDAT`, we need to know the size of each chunk before sending it, but we don't want to read the entire stream into memory. To support pipelining, we send the initial chunk as part of the pipelined data, but then fall back to sending requests when the remote server has replied to our most recent request. This trades network latency for memory use for message larger than 8K. Probably the 8K buffer is smaller than it should be - it would be good to base its size on data we have on typical message sizes.

@axiak 