### PR TITLE
Reuse config executor

### DIFF
--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -19,7 +19,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.net.ssl.SSLEngine;
@@ -77,7 +76,6 @@ public class IntegrationTest {
       "Hello!\r\n";
 
   private static final NioEventLoopGroup EVENT_LOOP_GROUP = new NioEventLoopGroup();
-  private static final ExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
 
   private InetSocketAddress serverAddress;
   private NettyServer smtpServer;
@@ -93,7 +91,7 @@ public class IntegrationTest {
     serverAddress = new InetSocketAddress(getFreePort());
     serverLog = mock(Logger.class);
     smtpServer = createAndStartSmtpServer(serverLog, serverAddress);
-    sessionFactory = new SmtpSessionFactory(EVENT_LOOP_GROUP, EXECUTOR_SERVICE);
+    sessionFactory = new SmtpSessionFactory(EVENT_LOOP_GROUP);
 
     when(serverLog.isDebugEnabled()).thenReturn(true);
   }

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -71,8 +71,6 @@ public class SmtpSessionTest {
   private static final SmtpRequest HELO_REQUEST = new DefaultSmtpRequest(SmtpCommand.HELO);
   private static final SmtpRequest HELP_REQUEST = new DefaultSmtpRequest(SmtpCommand.HELP);
 
-  private static final SmtpCommand BDAT = SmtpCommand.valueOf("BDAT");
-
   private static final SmtpSessionConfig CONFIG = SmtpSessionConfig.forRemoteAddress("127.0.0.1", 25).withExecutor(SmtpSessionConfig.DIRECT_EXECUTOR);
 
   private ResponseHandler responseHandler;
@@ -85,6 +83,7 @@ public class SmtpSessionTest {
   private ArgumentCaptor<ByteBuf> byteBufCaptor;
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setup() {
     channel = mock(Channel.class);
     pipeline = mock(ChannelPipeline.class);
@@ -486,6 +485,7 @@ public class SmtpSessionTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void itSendsChunksOneAtATime() throws Exception {
     List<String> chunks = Lists.newArrayList("first chunk", "number two", "last one");
     MessageContent content = mock(MessageContent.class);
@@ -498,7 +498,7 @@ public class SmtpSessionTest {
 
     when(responseHandler.createResponseFuture(anyInt(), any())).thenReturn(future1, future2, future3);
 
-    CompletableFuture<SmtpClientResponse[]> future = session.send(ALICE, Collections.singleton(BOB), content);
+    session.send(ALICE, Collections.singleton(BOB), content);
 
     InOrder order = inOrder(channel);
     order.verify(channel).write(req(SmtpCommand.MAIL, "FROM:<" + ALICE + ">"));


### PR DESCRIPTION
We don't need an `Executor` to be passed to `SmtpSessionFactory` because we can get it from the config.

@axiak 