### PR TITLE
Fix buffer leaks

### DIFF
--- a/src/test/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStreamTest.java
@@ -44,11 +44,12 @@ public class CrlfTerminatingChunkedStreamTest {
 
     CompositeByteBuf destBuffer = ALLOCATOR.compositeBuffer();
     while (!chunkedStream.isEndOfInput()) {
-      destBuffer.addComponent(true, chunkedStream.readChunk(ALLOCATOR).retain());
+      destBuffer.addComponent(true, chunkedStream.readChunk(ALLOCATOR));
     }
 
     byte[] bytes = new byte[destBuffer.readableBytes()];
     destBuffer.getBytes(0, bytes);
+    destBuffer.release();
     return new String(bytes, CharsetUtil.UTF_8);
   }
 }

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 
 public class DotStuffingChunkedStreamTest {
   private static final String CRLF = "\r\n";
@@ -51,12 +52,15 @@ public class DotStuffingChunkedStreamTest {
     DotStuffingChunkedStream chunkedStream = new DotStuffingChunkedStream(stream, chunkSize);
 
     CompositeByteBuf destBuffer = ALLOCATOR.compositeBuffer();
+
     while (!chunkedStream.isEndOfInput()) {
-      destBuffer.addComponent(true, chunkedStream.readChunk(ALLOCATOR).retain());
+      destBuffer.addComponent(true, chunkedStream.readChunk(ALLOCATOR));
     }
 
     byte[] bytes = new byte[destBuffer.readableBytes()];
     destBuffer.getBytes(0, bytes);
+
+    ReferenceCountUtil.release(destBuffer);
     return new String(bytes, CharsetUtil.UTF_8);
   }
 }

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingTest.java
@@ -48,22 +48,6 @@ public class DotStuffingTest {
     assertThat(dotStuffUsingByteBuf("x", true, false)).isEqualTo("x");
   }
 
-  @Test
-  public void itRetainsSourceByteBufs() {
-    String testString = "abc\r\n.def\r\n.ghi\r\n.";
-
-    ByteBuf sourceBuffer = ALLOCATOR.buffer();
-    sourceBuffer.writeBytes(testString.getBytes(StandardCharsets.UTF_8));
-    assertThat(sourceBuffer.refCnt()).isEqualTo(1);
-
-    ByteBuf destBuffer = DotStuffing.createDotStuffedBuffer(ALLOCATOR, sourceBuffer, null, MessageTermination.ADD_CRLF);
-    assertThat(destBuffer.refCnt()).isEqualTo(1);
-
-    // should be able to release both of these successfully
-    sourceBuffer.release();
-    destBuffer.release();
-  }
-
   private String dotStuffUsingByteBuf(String testString) {
     return dotStuffUsingByteBuf(testString, true, true);
   }


### PR DESCRIPTION
Update tests and the `DotStuffing` class so we don't leak memory. With these changes no leaks are detected in `paranoid` mode, which checks every buffer when it's GC'd.

@axiak 