### PR TITLE
Multiple reponses

### DIFF
--- a/src/main/java/com/hubspot/smtp/TestApp.java
+++ b/src/main/java/com/hubspot/smtp/TestApp.java
@@ -63,17 +63,17 @@ class TestApp {
 
     SmtpSessionConfig config = SmtpSessionConfig.forRemoteAddress("localhost", 9925);
 
-    CompletableFuture<SmtpClientResponse[]> future = new SmtpSessionFactory(EVENT_LOOP_GROUP).connect(config)
+    CompletableFuture<SmtpClientResponse> future = new SmtpSessionFactory(EVENT_LOOP_GROUP).connect(config)
         .thenCompose(r -> r.getSession().send(req(EHLO, "hubspot.com")))
         .thenCompose(r -> r.getSession().sendPipelined(req(MAIL, "FROM:test@example.com"), req(RCPT, "TO:person1@example.com"), req(DATA)));
 
     for (int i = 1; i < messageCount; i++) {
       String recipient = "TO:person" + i + "@example.com";
-      future = future.thenCompose(r -> r[0].getSession().sendPipelined(contentProvider.get(), req(RSET), req(MAIL, "FROM:test@example.com"), req(RCPT, recipient), req(DATA)));
+      future = future.thenCompose(r -> r.getSession().sendPipelined(contentProvider.get(), req(RSET), req(MAIL, "FROM:test@example.com"), req(RCPT, recipient), req(DATA)));
     }
 
-    future.thenCompose(r -> r[0].getSession().sendPipelined(contentProvider.get(), req(QUIT)))
-        .thenCompose(r -> r[0].getSession().close())
+    future.thenCompose(r -> r.getSession().sendPipelined(contentProvider.get(), req(QUIT)))
+        .thenCompose(r -> r.getSession().close())
         .join();
   }
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpClientResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpClientResponse.java
@@ -1,42 +1,46 @@
 package com.hubspot.smtp.client;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.hubspot.smtp.utils.SmtpResponses;
 
 import io.netty.handler.codec.smtp.SmtpResponse;
 
-public class SmtpClientResponse implements SmtpResponse {
-  private final SmtpResponse response;
+public class SmtpClientResponse  {
   private final SmtpSession session;
+  private final List<SmtpResponse> responses;
 
-  @VisibleForTesting
-  public SmtpClientResponse(SmtpResponse response, SmtpSession session) {
-    this.response = response;
+  public SmtpClientResponse(SmtpSession session, SmtpResponse response) {
+    this.responses = ImmutableList.of(response);
     this.session = session;
   }
 
-  @Override
-  public int code() {
-    return response.code();
+  public SmtpClientResponse(SmtpSession session, Iterable<SmtpResponse> responses) {
+    this.responses = ImmutableList.copyOf(responses);
+    this.session = session;
   }
 
-  @Override
-  public List<CharSequence> details() {
-    return response.details();
+  public SmtpClientResponse(SmtpSession session, SmtpResponse[] responses) {
+    this.responses = ImmutableList.copyOf(responses);
+    this.session = session;
   }
 
   public SmtpSession getSession() {
     return session;
   }
 
+  public boolean containsError() {
+    return responses.stream().anyMatch(SmtpResponses::isError);
+  }
+
+  public List<SmtpResponse> getResponses() {
+    return responses;
+  }
+
   @Override
   public String toString() {
-    if (response == null) {
-      return super.toString();
-    } else {
-      return SmtpResponses.toString(response);
-    }
+    return responses.stream().map(SmtpResponses::toString).collect(Collectors.joining("; "));
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -54,7 +54,7 @@ public class SmtpSessionFactory implements Closeable  {
         allChannels.add(channel);
 
         SmtpSession session = new SmtpSession(channel, responseHandler, config);
-        applyOnExecutor(config, initialResponseFuture, r -> connectFuture.complete(new SmtpClientResponse(r[0], session)));
+        applyOnExecutor(config, initialResponseFuture, r -> connectFuture.complete(new SmtpClientResponse(session, r[0])));
       } else {
         LOG.error("Could not connect to {}", config.getRemoteAddress(), f.cause());
         config.getEffectiveExecutor().execute(() -> connectFuture.completeExceptionally(f.cause()));

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -68,9 +68,9 @@ public class SmtpSessionFactory implements Closeable  {
     return TimeUnit.NANOSECONDS.convert(duration.getNano(), TimeUnit.MILLISECONDS);
   }
 
-  private <R, T> CompletableFuture<R> applyOnExecutor(SmtpSessionConfig config, CompletableFuture<T> eventLoopFuture, Function<T, R> mapper) {
+  private <R, T> void applyOnExecutor(SmtpSessionConfig config, CompletableFuture<T> eventLoopFuture, Function<T, R> mapper) {
     // use handleAsync to ensure exceptions and other callbacks are completed on the ExecutorService thread
-    return eventLoopFuture.handleAsync((rs, e) -> {
+    eventLoopFuture.handleAsync((rs, e) -> {
       if (e != null) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
Changes `SmtpClientResponse` so it can hold more than one response. This means we no longer have to deal with arrays of this type and makes client code simpler.

@axiak 