### PR TITLE
Supply requests when calling interceptors

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/CompositeSendInterceptor.java
+++ b/src/main/java/com/hubspot/smtp/client/CompositeSendInterceptor.java
@@ -8,7 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
-import io.netty.handler.codec.smtp.SmtpCommand;
+import io.netty.handler.codec.smtp.SmtpRequest;
 import io.netty.handler.codec.smtp.SmtpResponse;
 
 public class CompositeSendInterceptor implements SendInterceptor {
@@ -43,8 +43,8 @@ public class CompositeSendInterceptor implements SendInterceptor {
   }
 
   @Override
-  public CompletableFuture<List<SmtpResponse>> aroundCommand(SmtpCommand command, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
-    return rootInterceptor.aroundCommand(command, next);
+  public CompletableFuture<List<SmtpResponse>> aroundRequest(SmtpRequest request, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    return rootInterceptor.aroundRequest(request, next);
   }
 
   @Override
@@ -53,8 +53,8 @@ public class CompositeSendInterceptor implements SendInterceptor {
   }
 
   @Override
-  public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(Supplier<CompletableFuture<List<SmtpResponse>>> next) {
-    return rootInterceptor.aroundPipelinedSequence(next);
+  public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    return rootInterceptor.aroundPipelinedSequence(requests, next);
   }
 
   private static class InterceptorWrapper implements SendInterceptor {
@@ -67,8 +67,8 @@ public class CompositeSendInterceptor implements SendInterceptor {
     }
 
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundCommand(SmtpCommand command, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
-      return thisInterceptor.aroundCommand(command, () -> nextInterceptor.aroundCommand(command, next));
+    public CompletableFuture<List<SmtpResponse>> aroundRequest(SmtpRequest request, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+      return thisInterceptor.aroundRequest(request, () -> nextInterceptor.aroundRequest(request, next));
     }
 
     @Override
@@ -77,8 +77,8 @@ public class CompositeSendInterceptor implements SendInterceptor {
     }
 
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(Supplier<CompletableFuture<List<SmtpResponse>>> next) {
-      return thisInterceptor.aroundData(() -> nextInterceptor.aroundPipelinedSequence(next));
+    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+      return thisInterceptor.aroundData(() -> nextInterceptor.aroundPipelinedSequence(requests, next));
     }
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/SendInterceptor.java
+++ b/src/main/java/com/hubspot/smtp/client/SendInterceptor.java
@@ -4,11 +4,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-import io.netty.handler.codec.smtp.SmtpCommand;
+import io.netty.handler.codec.smtp.SmtpRequest;
 import io.netty.handler.codec.smtp.SmtpResponse;
 
 public interface SendInterceptor {
-  CompletableFuture<List<SmtpResponse>> aroundCommand(SmtpCommand command, Supplier<CompletableFuture<List<SmtpResponse>>> next);
+  CompletableFuture<List<SmtpResponse>> aroundRequest(SmtpRequest request, Supplier<CompletableFuture<List<SmtpResponse>>> next);
   CompletableFuture<List<SmtpResponse>> aroundData(Supplier<CompletableFuture<List<SmtpResponse>>> next);
-  CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(Supplier<CompletableFuture<List<SmtpResponse>>> next);
+  CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next);
 }

--- a/src/test/java/com/hubspot/smtp/client/CompositeSendInterceptorTest.java
+++ b/src/test/java/com/hubspot/smtp/client/CompositeSendInterceptorTest.java
@@ -11,16 +11,19 @@ import java.util.function.Supplier;
 import org.assertj.core.util.Lists;
 import org.junit.Test;
 
+import io.netty.handler.codec.smtp.DefaultSmtpRequest;
 import io.netty.handler.codec.smtp.DefaultSmtpResponse;
 import io.netty.handler.codec.smtp.SmtpCommand;
+import io.netty.handler.codec.smtp.SmtpRequest;
 import io.netty.handler.codec.smtp.SmtpResponse;
 
 public class CompositeSendInterceptorTest {
+  private static final DefaultSmtpRequest MAIL_REQUEST = new DefaultSmtpRequest(SmtpCommand.MAIL);
   private static final List<SmtpResponse> DEFAULT_RESPONSE = Lists.newArrayList(new DefaultSmtpResponse(250, "OK"));
 
   private static final SendInterceptor RESPONSE_SEND_INTERCEPTOR = new SendInterceptor() {
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundCommand(SmtpCommand command, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    public CompletableFuture<List<SmtpResponse>> aroundRequest(SmtpRequest request, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
       return CompletableFuture.completedFuture(DEFAULT_RESPONSE);
     }
 
@@ -30,14 +33,14 @@ public class CompositeSendInterceptorTest {
     }
 
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
       return CompletableFuture.completedFuture(DEFAULT_RESPONSE);
     }
   };
 
   private static final SendInterceptor ALWAYS_FAILS_SEND_INTERCEPTOR = new SendInterceptor() {
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundCommand(SmtpCommand command, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    public CompletableFuture<List<SmtpResponse>> aroundRequest(SmtpRequest request, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
       return getFailedFuture();
     }
 
@@ -47,7 +50,7 @@ public class CompositeSendInterceptorTest {
     }
 
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
       return getFailedFuture();
     }
 
@@ -60,7 +63,7 @@ public class CompositeSendInterceptorTest {
 
   private static final SendInterceptor PASS_THROUGH_SEND_INTERCEPTOR = new SendInterceptor() {
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundCommand(SmtpCommand command, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    public CompletableFuture<List<SmtpResponse>> aroundRequest(SmtpRequest request, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
       return next.get();
     }
 
@@ -70,21 +73,21 @@ public class CompositeSendInterceptorTest {
     }
 
     @Override
-    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(Supplier<CompletableFuture<List<SmtpResponse>>> next) {
+    public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
       return next.get();
     }
   };
 
   @Test
   public void itWrapsInterceptors() throws Exception {
-    List<SmtpResponse> responses = CompositeSendInterceptor.of(RESPONSE_SEND_INTERCEPTOR).aroundCommand(SmtpCommand.MAIL, null).get();
+    List<SmtpResponse> responses = CompositeSendInterceptor.of(RESPONSE_SEND_INTERCEPTOR).aroundRequest(MAIL_REQUEST, null).get();
 
     assertThat(responses).isEqualTo(DEFAULT_RESPONSE);
   }
 
   @Test
   public void itOrdersInterceptors() throws Exception {
-    List<SmtpResponse> responses = CompositeSendInterceptor.of(PASS_THROUGH_SEND_INTERCEPTOR, RESPONSE_SEND_INTERCEPTOR).aroundCommand(SmtpCommand.MAIL, null).get();
+    List<SmtpResponse> responses = CompositeSendInterceptor.of(PASS_THROUGH_SEND_INTERCEPTOR, RESPONSE_SEND_INTERCEPTOR).aroundRequest(MAIL_REQUEST, null).get();
 
     assertThat(responses).isEqualTo(DEFAULT_RESPONSE);
   }
@@ -92,9 +95,9 @@ public class CompositeSendInterceptorTest {
   @Test
   public void itExecutesInterceptorsLazily() throws Exception {
     SendInterceptor mockSendInterceptor = mock(SendInterceptor.class);
-    CompletableFuture<List<SmtpResponse>> future = CompositeSendInterceptor.of(ALWAYS_FAILS_SEND_INTERCEPTOR, mockSendInterceptor).aroundCommand(SmtpCommand.MAIL, null);
+    CompletableFuture<List<SmtpResponse>> future = CompositeSendInterceptor.of(ALWAYS_FAILS_SEND_INTERCEPTOR, mockSendInterceptor).aroundRequest(MAIL_REQUEST, null);
 
     assertThat(future.isCompletedExceptionally()).isTrue();
-    verify(mockSendInterceptor, never()).aroundCommand(any(), any());
+    verify(mockSendInterceptor, never()).aroundRequest(any(), any());
   }
 }


### PR DESCRIPTION
If using a `SendInterceptor` for logging, it's useful to get the full `SmtpRequest` instead of just the command. This PR provides that, and also provides requests sent as part of pipelined sequences.

@axiak 