### PR TITLE
Format responses as a series of lines

### DIFF
--- a/src/main/java/com/hubspot/smtp/utils/SmtpResponses.java
+++ b/src/main/java/com/hubspot/smtp/utils/SmtpResponses.java
@@ -1,6 +1,9 @@
 package com.hubspot.smtp.utils;
 
+import java.util.List;
+
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 
 import io.netty.handler.codec.smtp.SmtpResponse;
 
@@ -13,6 +16,28 @@ public final class SmtpResponses {
 
   public static String toString(SmtpResponse response) {
     return response.code() + " " + SPACE_JOINER.join(response.details());
+  }
+
+  public static List<String> getLines(SmtpResponse response) {
+    String[] lines = new String[response.details().size()];
+
+    for (int i = 0; i < response.details().size(); i++) {
+      StringBuilder responseBuilder = new StringBuilder();
+
+      responseBuilder.append(response.code());
+
+      if (i == response.details().size() - 1) {
+        responseBuilder.append(" ");
+      } else {
+        responseBuilder.append("-");
+      }
+
+      responseBuilder.append(response.details().get(i));
+
+      lines[i] = responseBuilder.toString();
+    }
+
+    return ImmutableList.copyOf(lines);
   }
 
   public static boolean isTransientError(SmtpResponse response) {

--- a/src/test/java/com/hubspot/smtp/utils/SmtpResponsesTest.java
+++ b/src/test/java/com/hubspot/smtp/utils/SmtpResponsesTest.java
@@ -4,17 +4,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import com.google.common.collect.Lists;
+
 import io.netty.handler.codec.smtp.DefaultSmtpResponse;
 import io.netty.handler.codec.smtp.SmtpResponse;
 
 public class SmtpResponsesTest {
   private static final SmtpResponse OK_RESPONSE = new DefaultSmtpResponse(250, "ARG1", "ARG2");
+  private static final SmtpResponse EHLO_RESPONSE = new DefaultSmtpResponse(250, "PIPELINING", "CHUNKING");
   private static final SmtpResponse TRANSIENT_ERROR_RESPONSE = new DefaultSmtpResponse(400);
   private static final SmtpResponse PERMANENT_ERROR_RESPONSE = new DefaultSmtpResponse(500);
 
   @Test
   public void itFormatsResponsesAsAString() {
     assertThat(SmtpResponses.toString(OK_RESPONSE)).isEqualTo("250 ARG1 ARG2");
+  }
+
+  @Test
+  public void itFormatsResponsesAsALines() {
+    assertThat(SmtpResponses.getLines(EHLO_RESPONSE)).isEqualTo(Lists.newArrayList("250-PIPELINING", "250 CHUNKING"));
   }
 
   @Test


### PR DESCRIPTION
Adds a helper method to format an `SmtpResponse` as a series of lines as it would have been originally received from the remote server.

@axiak 