### PR TITLE
Timeout only while waiting for responses

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -9,7 +9,6 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.smtp.SmtpRequestEncoder;
 import io.netty.handler.codec.smtp.SmtpResponseDecoder;
 import io.netty.handler.stream.ChunkedWriteHandler;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 
 class Initializer extends ChannelInitializer<SocketChannel> {
   private static final int MAX_LINE_LENGTH = 1000;
@@ -33,7 +32,6 @@ class Initializer extends ChannelInitializer<SocketChannel> {
     handlers.add(new SmtpRequestEncoder());
     handlers.add(new SmtpResponseDecoder(MAX_LINE_LENGTH));
     handlers.add(new ChunkedWriteHandler());
-    handlers.add(new ReadTimeoutHandler(Math.toIntExact(config.getReadTimeout().getSeconds())));
 
     config.getKeepAliveTimeout().ifPresent(timeout -> handlers.add(new KeepAliveHandler(responseHandler, config.getConnectionId(), timeout)));
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -32,7 +32,7 @@ public class SmtpSessionFactory implements Closeable  {
   }
 
   public CompletableFuture<SmtpClientResponse> connect(SmtpSessionConfig config) {
-    ResponseHandler responseHandler = new ResponseHandler(config.getConnectionId());
+    ResponseHandler responseHandler = new ResponseHandler(config.getConnectionId(), config.getReadTimeout());
     CompletableFuture<List<SmtpResponse>> initialResponseFuture = responseHandler.createResponseFuture(1, () -> "initial response");
 
     Bootstrap bootstrap = new Bootstrap()


### PR DESCRIPTION
Changes the behaviour of the configured response timeout so it only applies while waiting for a response. The previous behaviour was more like an idle timer and closed connections unnecessarily.

@axiak 