### PR TITLE
Fix: doesn't dot stuff some messages

### DIFF
--- a/src/main/java/com/hubspot/smtp/messages/DotStuffing.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffing.java
@@ -107,7 +107,7 @@ final class DotStuffing {
         if (i + 1 < length && buffer.getByte(i + 1) == DOT) {
           return i + 1;
         } else {
-          break;
+          continue;
         }
       }
     }

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingTest.java
@@ -32,6 +32,7 @@ public class DotStuffingTest {
     assertThat(dotStuffUsingByteBuf("abc\r\n.def")).isEqualTo("abc\r\n..def" + CRLF);
     assertThat(dotStuffUsingByteBuf("abc\r\n.")).isEqualTo("abc\r\n.." + CRLF);
     assertThat(dotStuffUsingByteBuf("abc\r\n.def\r\n.ghi\r\n.")).isEqualTo("abc\r\n..def\r\n..ghi\r\n.." + CRLF);
+    assertThat(dotStuffUsingByteBuf("abc\r\ndef\r\n.ghi\r\n.")).isEqualTo("abc\r\ndef\r\n..ghi\r\n.." + CRLF);
 
     // does not add
     assertThat(dotStuffUsingByteBuf("abc\r\ndef.")).isEqualTo("abc\r\ndef." + CRLF);


### PR DESCRIPTION
Messages that contained a `\r\n` sequence before a `\r\n.\r\n` sequence weren't properly detected, which meant they weren't dot-stuffed.

@axiak 