### PR TITLE
Ehlo after tls

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/CompositeSendInterceptor.java
+++ b/src/main/java/com/hubspot/smtp/client/CompositeSendInterceptor.java
@@ -61,7 +61,7 @@ public class CompositeSendInterceptor implements SendInterceptor {
     private final SendInterceptor thisInterceptor;
     private final SendInterceptor nextInterceptor;
 
-    public InterceptorWrapper(SendInterceptor thisInterceptor, SendInterceptor nextInterceptor) {
+    InterceptorWrapper(SendInterceptor thisInterceptor, SendInterceptor nextInterceptor) {
       this.thisInterceptor = thisInterceptor;
       this.nextInterceptor = nextInterceptor;
     }

--- a/src/main/java/com/hubspot/smtp/client/EhloResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/EhloResponse.java
@@ -13,9 +13,11 @@ import com.google.common.collect.Iterables;
 import com.google.common.primitives.Longs;
 
 public class EhloResponse {
-  static final EhloResponse EMPTY = EhloResponse.parse(Collections.emptyList());
+  static final EhloResponse EMPTY = EhloResponse.parse("", Collections.emptyList());
 
   private static final Splitter WHITESPACE_SPLITTER = Splitter.on(CharMatcher.WHITESPACE);
+
+  private final String ehloDomain;
   private final ImmutableSet<String> supportedExtensions;
 
   private EnumSet<Extension> extensions;
@@ -23,17 +25,17 @@ public class EhloResponse {
   private boolean isAuthPlainSupported;
   private boolean isAuthLoginSupported;
 
-
-  public static EhloResponse parse(Iterable<CharSequence> lines) {
-    return parse(lines, EnumSet.noneOf(Extension.class));
+  public static EhloResponse parse(String ehloDomain, Iterable<CharSequence> lines) {
+    return parse(ehloDomain, lines, EnumSet.noneOf(Extension.class));
   }
 
-  public static EhloResponse parse(Iterable<CharSequence> lines, EnumSet<Extension> disabledExtensions) {
-    return new EhloResponse(lines, disabledExtensions);
+  public static EhloResponse parse(String ehloDomain, Iterable<CharSequence> lines, EnumSet<Extension> disabledExtensions) {
+    return new EhloResponse(ehloDomain, lines, disabledExtensions);
   }
 
-  private EhloResponse(Iterable<CharSequence> lines, EnumSet<Extension> disabledExtensions) {
-    extensions = EnumSet.noneOf(Extension.class);
+  private EhloResponse(String ehloDomain, Iterable<CharSequence> lines, EnumSet<Extension> disabledExtensions) {
+    this.ehloDomain = ehloDomain;
+    this.extensions = EnumSet.noneOf(Extension.class);
 
     for (CharSequence line : lines) {
       List<String> parts = WHITESPACE_SPLITTER.splitToList(line);
@@ -76,6 +78,10 @@ public class EhloResponse {
         isAuthLoginSupported = true;
       }
     }
+  }
+
+  public String getEhloDomain() {
+    return ehloDomain;
   }
 
   public boolean isSupported(Extension ext) {

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -37,7 +37,7 @@ public class EhloResponseTest {
 
   @Test
   public void itIgnoresDisabledExtensions() {
-    EhloResponse response = EhloResponse.parse(Lists.newArrayList("smtp.example.com Hello client.example.com", "8BITMIME", "STARTTLS"),
+    EhloResponse response = EhloResponse.parse("", Lists.newArrayList("smtp.example.com Hello client.example.com", "8BITMIME", "STARTTLS"),
         EnumSet.of(Extension.EIGHT_BIT_MIME));
 
     assertThat(response.isSupported(Extension.EIGHT_BIT_MIME)).isFalse();
@@ -111,6 +111,6 @@ public class EhloResponseTest {
   }
 
   private EhloResponse parse(CharSequence... lines) {
-    return EhloResponse.parse(Lists.newArrayList(lines));
+    return EhloResponse.parse("", Lists.newArrayList(lines));
   }
 }


### PR DESCRIPTION
Sends EHLO after successfully connecting via TLS, as recommended by [the spec](https://tools.ietf.org/html/rfc3207#section-4.2).

@axiak 