### PR TITLE
Fix: end of stream causes NPE

### DIFF
--- a/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/DotStuffingChunkedStream.java
@@ -24,6 +24,9 @@ class DotStuffingChunkedStream extends ChunkedStream {
   @Override
   public ByteBuf readChunk(ByteBufAllocator allocator) throws Exception {
     ByteBuf chunk = super.readChunk(allocator);
+    if (chunk == null) {
+      return null;
+    }
 
     byte[] prevChunkTrailingBytes = new byte[2];
     prevChunkTrailingBytes[0] = trailingBytes[0];

--- a/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/DotStuffingChunkedStreamTest.java
@@ -31,6 +31,14 @@ public class DotStuffingChunkedStreamTest {
     }
   }
 
+  @Test
+  public void itReturnsNullIfThereAreNoMoreBytesInTheStream() throws Exception {
+    ByteArrayInputStream stream = new ByteArrayInputStream(new byte[0]);
+    DotStuffingChunkedStream chunkedStream = new DotStuffingChunkedStream(stream, SANE_CHUNK_SIZE);
+
+    assertThat(chunkedStream.readChunk(ALLOCATOR)).isNull();
+  }
+
   private void assertDotStuffingWithChunkSize(int chunkSize) throws Exception {
     // adds
     assertThat(dotStuff(".", chunkSize)).isEqualTo(".." + CRLF);


### PR DESCRIPTION
Fixes a bug where a NullPointerException could be thrown if we asked DotStuffingChunkedStream for a chunk from a closed stream, or one that had already been fully consumed.

@axiak 