### PR TITLE
Support disabling the response timeout

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -19,15 +19,11 @@ abstract class AbstractSmtpSessionConfig {
   public abstract InetSocketAddress getRemoteAddress();
   public abstract Optional<InetSocketAddress> getLocalAddress();
   public abstract Optional<Duration> getKeepAliveTimeout();
+  public abstract Optional<Duration> getReadTimeout();
   public abstract Optional<SendInterceptor> getSendInterceptor();
 
   @Default
   public Duration getConnectionTimeout() {
-    return Duration.ofMinutes(2);
-  }
-
-  @Default
-  public Duration getReadTimeout() {
     return Duration.ofMinutes(2);
   }
 

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
@@ -30,7 +31,7 @@ public class ResponseHandlerTest {
 
   @Before
   public void setup() {
-    responseHandler = new ResponseHandler(CONNECTION_ID, Duration.ofMinutes(2));
+    responseHandler = new ResponseHandler(CONNECTION_ID, Optional.empty());
     context = mock(ChannelHandlerContext.class);
   }
 
@@ -176,7 +177,7 @@ public class ResponseHandlerTest {
 
   @Test
   public void itCompletesExceptionallyIfTheResonseTimeoutIsExceeded() throws Exception {
-    ResponseHandler impatientHandler = new ResponseHandler(CONNECTION_ID, Duration.ofMillis(200));
+    ResponseHandler impatientHandler = new ResponseHandler(CONNECTION_ID, Optional.of(Duration.ofMillis(200)));
 
     CompletableFuture<List<SmtpResponse>> responseFuture = impatientHandler.createResponseFuture(1, DEBUG_STRING);
     assertThat(responseFuture.isCompletedExceptionally()).isFalse();


### PR DESCRIPTION
Makes the response timeout optional so clients can choose not to use it.

@axiak 