### PR TITLE
Return a fixed estimate when streams cannot mark

### DIFF
--- a/src/test/java/com/hubspot/smtp/messages/InputStreamMessageContentTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/InputStreamMessageContentTest.java
@@ -1,6 +1,12 @@
 package com.hubspot.smtp.messages;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.OptionalInt;
+
+import org.junit.Test;
 
 import com.google.common.io.ByteSource;
 
@@ -8,5 +14,18 @@ public class InputStreamMessageContentTest extends MessageContentTest {
   @Override
   protected MessageContent createContent(byte[] bytes) {
     return new InputStreamMessageContent(ByteSource.wrap(bytes), OptionalInt.of(bytes.length), MessageContentEncoding.UNKNOWN);
+  }
+
+  @Test
+  public void itUsesAFixedValueForStreamsThatDoNotSupportMark() {
+    ByteArrayInputStream stream = new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)) {
+      @Override
+      public boolean markSupported() {
+        return false;
+      }
+    };
+
+    MessageContent content = new InputStreamMessageContent(() -> stream, OptionalInt.empty(), MessageContentEncoding.UNKNOWN);
+    assertThat(content.get8bitCharacterProportion()).isEqualTo(0.1F);
   }
 }


### PR DESCRIPTION
Streams that don't support marking were fully consumed while we tried to estimate their 8 bit content, and the error was swallowed. This could lead to us not submitting any content at all, and the session hanging.

This change returns a default (`0.1`) if we can't estimate the 8 bit content. In future, when we support rewriting 8 bit messages to 7 bit, this should mean we use quoted-printable and not base64, which should be appropriate for most messages.

@axiak 