### PR TITLE
Add xoauth2 auth mechanism

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/EhloResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/EhloResponse.java
@@ -24,6 +24,7 @@ public class EhloResponse {
   private Optional<Long> maxMessageSize = Optional.empty();
   private boolean isAuthPlainSupported;
   private boolean isAuthLoginSupported;
+  private boolean isAuthXoauth2Supported;
 
   public static EhloResponse parse(String ehloDomain, Iterable<CharSequence> lines) {
     return parse(ehloDomain, lines, EnumSet.noneOf(Extension.class));
@@ -76,6 +77,8 @@ public class EhloResponse {
         isAuthPlainSupported = true;
       } else if (s.equalsIgnoreCase("login")) {
         isAuthLoginSupported = true;
+      } else if (s.equalsIgnoreCase("xoauth2")) {
+        isAuthXoauth2Supported = true;
       }
     }
   }
@@ -94,6 +97,10 @@ public class EhloResponse {
 
   public boolean isAuthLoginSupported() {
     return isAuthLoginSupported;
+  }
+
+  public boolean isAuthXoauth2Supported() {
+    return isAuthXoauth2Supported;
   }
 
   public Optional<Long> getMaxMessageSize() {

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -78,6 +78,7 @@ public class SmtpSession {
   private static final SmtpCommand BDAT_COMMAND = SmtpCommand.valueOf("BDAT");
   private static final String AUTH_PLAIN_MECHANISM = "PLAIN";
   private static final String AUTH_LOGIN_MECHANISM = "LOGIN";
+  private static final String AUTH_XOAUTH2_MECHANISM = "XOAUTH2";
   private static final String CRLF = "\r\n";
 
   private final Channel channel;
@@ -401,6 +402,13 @@ public class SmtpSession {
 
     String s = String.format("%s\0%s\0%s", username, username, password);
     return send(new DefaultSmtpRequest(AUTH_COMMAND, AUTH_PLAIN_MECHANISM, encodeBase64(s)));
+  }
+
+  public CompletableFuture<SmtpClientResponse> authXoauth2(String username, String accessToken) {
+    Preconditions.checkState(ehloResponse.isAuthXoauth2Supported(), "Auth xoauth2 is not supported on this server");
+
+    String s = String.format("user=%s\001auth=Bearer %s\001\001", username, accessToken);
+    return send(new DefaultSmtpRequest(AUTH_COMMAND, AUTH_XOAUTH2_MECHANISM, encodeBase64(s)));
   }
 
   public CompletableFuture<SmtpClientResponse> authLogin(String username, String password) {


### PR DESCRIPTION
This PR adds support for the `XOAUTH2` authentication mechanism, mainly used by [gmail](https://developers.google.com/gmail/imap/xoauth2-protocol). The code here is pretty simple, and basically just mimicks the existing auth structure, with some added formatting for what gmail expects when using `XOAUTH2`.

I tested this using the `TestApp` and it works! Haven't added any real tests yet though.