### PR TITLE
Add exception handler config for connection errors

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.EnumSet;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
@@ -21,6 +22,7 @@ abstract class AbstractSmtpSessionConfig {
   public abstract Optional<Duration> getKeepAliveTimeout();
   public abstract Optional<Duration> getReadTimeout();
   public abstract Optional<SendInterceptor> getSendInterceptor();
+  public abstract Optional<Consumer<Throwable>> getExceptionHandler();
 
   @Default
   public Duration getConnectionTimeout() {

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -32,7 +32,7 @@ public class SmtpSessionFactory implements Closeable  {
   }
 
   public CompletableFuture<SmtpClientResponse> connect(SmtpSessionConfig config) {
-    ResponseHandler responseHandler = new ResponseHandler(config.getConnectionId(), config.getReadTimeout());
+    ResponseHandler responseHandler = new ResponseHandler(config.getConnectionId(), config.getReadTimeout(), config.getExceptionHandler());
     CompletableFuture<List<SmtpResponse>> initialResponseFuture = responseHandler.createResponseFuture(1, () -> "initial response");
 
     Bootstrap bootstrap = new Bootstrap()


### PR DESCRIPTION
Exceptions caught during message sends are returned by completing futures exceptionally, but exceptions encountered outside a send (e.g. a connection closed unexpectedly by the remote host) were not.

This change provides a config option so clients can choose to be notified when connection-level errors occur.