### PR TITLE
Fix: interceptor delegates to wrong event

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/CompositeSendInterceptor.java
+++ b/src/main/java/com/hubspot/smtp/client/CompositeSendInterceptor.java
@@ -102,7 +102,7 @@ public class CompositeSendInterceptor implements SendInterceptor {
 
     @Override
     public CompletableFuture<List<SmtpResponse>> aroundPipelinedSequence(List<SmtpRequest> requests, Supplier<CompletableFuture<List<SmtpResponse>>> next) {
-      return thisInterceptor.aroundData(() -> nextInterceptor.aroundPipelinedSequence(requests, next));
+      return thisInterceptor.aroundPipelinedSequence(requests, () -> nextInterceptor.aroundPipelinedSequence(requests, next));
     }
   }
 }


### PR DESCRIPTION
copy-paste error 😢 that led to requests not being logged when pipelining