### PR TITLE
Don't call connection exception handler

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/ResponseHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/ResponseHandler.java
@@ -103,12 +103,14 @@ class ResponseHandler extends SimpleChannelInboundHandler<SmtpResponse> {
     ResponseCollector collector = responseCollector.getAndSet(null);
     if (collector != null) {
       collector.completeExceptionally(cause);
-    }
-
-    if (exceptionHandler.isPresent()) {
-      exceptionHandler.get().accept(cause);
     } else {
-      super.exceptionCaught(ctx, cause);
+      // this exception can't get back to the client via a future,
+      // use the connection exception handler if possible
+      if (exceptionHandler.isPresent()) {
+        exceptionHandler.get().accept(cause);
+      } else {
+        super.exceptionCaught(ctx, cause);
+      }
     }
   }
 

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -45,8 +45,6 @@ public class ResponseHandlerTest {
 
     assertThat(f.isCompletedExceptionally()).isTrue();
     assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class).hasCause(testException);
-
-    verify(context).fireExceptionCaught(testException);
   }
 
   @Test
@@ -196,6 +194,19 @@ public class ResponseHandlerTest {
     responseHandler.exceptionCaught(null, testException);
 
     verify(exceptionHandler).accept(testException);
+  }
+
+  @Test
+  public void itDoesNotPasExceptionsToTheProvidedHandlerIfThereIsAPendingFuture() throws Exception {
+    Consumer<Throwable> exceptionHandler = (Consumer<Throwable>) mock(Consumer.class);
+    ResponseHandler responseHandler = new ResponseHandler(CONNECTION_ID, Optional.empty(), Optional.of(exceptionHandler));
+
+    responseHandler.createResponseFuture(1, DEBUG_STRING);
+
+    Exception testException = new Exception("oh no");
+    responseHandler.exceptionCaught(null, testException);
+
+    verify(exceptionHandler, never()).accept(testException);
   }
 
   @Test


### PR DESCRIPTION
The connection exception handler is useful when it finds exceptions that wouldn't otherwise be detected.

If there is a pending future, this is the best way for clients to handle exceptions.

@axiak 