### PR TITLE
Send 8BITMIME parameter with MAIL command, not DATA

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -378,7 +378,7 @@ public class SmtpSession {
   }
 
   private CompletableFuture<SmtpClientResponse> sendAs8BitMime(String from, Collection<String> recipients, MessageContent content, Optional<SendInterceptor> sequenceInterceptor) {
-    return sendPipelinedIfPossible(SmtpRequests.mail(from), recipients, new DefaultSmtpRequest(SmtpCommand.DATA, "BODY=8BITMIME"), sequenceInterceptor)
+    return sendPipelinedIfPossible(SmtpRequests.mail(from, "BODY=8BITMIME"), recipients, SmtpRequests.data(), sequenceInterceptor)
         .thenSend(content.getDotStuffedContent(), EMPTY_LAST_CONTENT)
         .toResponses();
   }

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -688,9 +688,9 @@ public class SmtpSessionTest {
     CompletableFuture<SmtpClientResponse> future = session.send(ALICE, BOB, unknownContent);
 
     InOrder order = inOrder(channel);
-    order.verify(channel).write(req(SmtpCommand.MAIL, "FROM:<" + ALICE + ">"));
+    order.verify(channel).write(req(SmtpCommand.MAIL, "FROM:<" + ALICE + ">", "BODY=8BITMIME"));
     order.verify(channel).write(req(SmtpCommand.RCPT, "TO:<" + BOB + ">"));
-    order.verify(channel).write(req(SmtpCommand.DATA, "BODY=8BITMIME"));
+    order.verify(channel).write(req(SmtpCommand.DATA));
 
     responseFuture.complete(Lists.newArrayList(OK_RESPONSE, OK_RESPONSE, OK_RESPONSE));
 


### PR DESCRIPTION
The `BODY=8BITMIME` parameter [should be sent](https://tools.ietf.org/html/rfc6152#section-2) with the MAIL command, not DATA.

@axiak 