### PR TITLE
Fix: NPE in CrlfTerminatingChunkedStream

### DIFF
--- a/src/main/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStream.java
+++ b/src/main/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStream.java
@@ -33,7 +33,7 @@ class CrlfTerminatingChunkedStream extends ChunkedStream {
       return chunk;
     }
 
-    if (isTerminatedWithCrLf(chunk)) {
+    if (chunk == null || isTerminatedWithCrLf(chunk)) {
       return chunk;
     }
 

--- a/src/test/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStreamTest.java
+++ b/src/test/java/com/hubspot/smtp/messages/CrlfTerminatingChunkedStreamTest.java
@@ -34,6 +34,11 @@ public class CrlfTerminatingChunkedStreamTest {
     assertThat(terminate("0123456789", 3)).isEqualTo("0123456789" + CRLF);
   }
 
+  @Test
+  public void itDoesNotThrowNullPointerExceptionAtTheEndOfTheStream() throws Exception {
+    new CrlfTerminatingChunkedStream(new ByteArrayInputStream(new byte[0]), 8192).readChunk(ALLOCATOR);
+  }
+
   private String terminate(String testString) throws Exception {
     return terminate(testString, 8192);
   }


### PR DESCRIPTION
Fixes a `NullPointerException` that could be thrown at the end of a stream.

@axiak 