### PR TITLE
Ignore nulls in SMTP response details

### DIFF
--- a/src/main/java/com/hubspot/smtp/utils/SmtpResponses.java
+++ b/src/main/java/com/hubspot/smtp/utils/SmtpResponses.java
@@ -12,14 +12,18 @@ import io.netty.handler.codec.smtp.SmtpResponse;
  *
  */
 public final class SmtpResponses {
-  private static final Joiner SPACE_JOINER = Joiner.on(" ");
+  private static final Joiner SPACE_JOINER = Joiner.on(" ").skipNulls();
 
   private SmtpResponses() {
     throw new AssertionError("Cannot create static utility class");
   }
 
   public static String toString(SmtpResponse response) {
-    return response.code() + " " + SPACE_JOINER.join(response.details());
+    if (response.details().size() == 0) {
+      return Integer.toString(response.code());
+    } else {
+      return response.code() + " " + SPACE_JOINER.join(response.details());
+    }
   }
 
   public static List<String> getLines(SmtpResponse response) {

--- a/src/test/java/com/hubspot/smtp/utils/SmtpResponsesTest.java
+++ b/src/test/java/com/hubspot/smtp/utils/SmtpResponsesTest.java
@@ -11,6 +11,7 @@ import io.netty.handler.codec.smtp.SmtpResponse;
 
 public class SmtpResponsesTest {
   private static final SmtpResponse OK_RESPONSE = new DefaultSmtpResponse(250, "ARG1", "ARG2");
+  private static final SmtpResponse OK_NO_DETAILS_RESPONSE = new DefaultSmtpResponse(250);
   private static final SmtpResponse NO_DETAILS_RESPONSE = new DefaultSmtpResponse(250);
   private static final SmtpResponse EHLO_RESPONSE = new DefaultSmtpResponse(250, "PIPELINING", "CHUNKING");
   private static final SmtpResponse TRANSIENT_ERROR_RESPONSE = new DefaultSmtpResponse(400);
@@ -19,6 +20,12 @@ public class SmtpResponsesTest {
   @Test
   public void itFormatsResponsesAsAString() {
     assertThat(SmtpResponses.toString(OK_RESPONSE)).isEqualTo("250 ARG1 ARG2");
+    assertThat(SmtpResponses.toString(OK_NO_DETAILS_RESPONSE)).isEqualTo("250");
+  }
+
+  @Test
+  public void itIgnoresNullDetails() {
+    assertThat(SmtpResponses.toString(new DefaultSmtpResponse(250, null, "ARG2"))).isEqualTo("250 ARG2");
   }
 
   @Test


### PR DESCRIPTION
Sometimes `details()` contains null - this ensures we don't throw when this occurs.