### PR TITLE
Replace the SmtpRequestEncoder on the IO thread

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -297,7 +297,7 @@ public class SmtpSession {
         .whenComplete((response, throwable) -> {
           if (response != null && response.containsError()) {
             // to work around a bug until https://github.com/netty/netty/pull/6759 is released
-            channel.pipeline().replace(SmtpRequestEncoder.class, "SmtpRequestEncoder", new SmtpRequestEncoder());
+            channel.eventLoop().execute(() -> channel.pipeline().replace(SmtpRequestEncoder.class, "SmtpRequestEncoder", new SmtpRequestEncoder()));
           }
         });
   }


### PR DESCRIPTION
Previously this was run on the executor thread, which meant
there could be a race as two threads tried to replace it
at the same time.