### PR TITLE
Ignore max message size less than 1k

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -89,6 +89,7 @@ public class SmtpSession {
   private static final String AUTH_LOGIN_MECHANISM = "LOGIN";
   private static final String AUTH_XOAUTH2_MECHANISM = "XOAUTH2";
   private static final String CRLF = "\r\n";
+  private static final long VALID_MAX_MESSAGE_SIZE_THRESHOLD = 1_024L;
 
   private final Channel channel;
   private final ResponseHandler responseHandler;
@@ -686,8 +687,9 @@ public class SmtpSession {
       return;
     }
 
-    if (ehloResponse.getMaxMessageSize().get() < size.getAsInt()) {
-      throw new MessageTooLargeException(config.getConnectionId(), ehloResponse.getMaxMessageSize().get());
+    long maximumSize = ehloResponse.getMaxMessageSize().get();
+    if (maximumSize >= VALID_MAX_MESSAGE_SIZE_THRESHOLD && maximumSize < size.getAsInt()) {
+      throw new MessageTooLargeException(config.getConnectionId(), maximumSize);
     }
   }
 

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -178,6 +178,15 @@ public class SmtpSessionTest {
   }
 
   @Test
+  public void itIgnoresMaxMessageSizeIfItIsLowerThan1k() {
+    session.parseEhloResponse(EHLO_DOMAIN, Lists.newArrayList("SIZE 1023"));
+
+    MessageContent largeMessage = MessageContent.of(ByteSource.wrap(new byte[1024]));
+
+    session.send(largeMessage);
+  }
+
+  @Test
   public void itWrapsTheResponse() throws ExecutionException, InterruptedException {
     CompletableFuture<SmtpClientResponse> future = session.send(SMTP_REQUEST);
 


### PR DESCRIPTION
If a server responds with a very small maximum message size, it's likely to be an error. We should try anyway in these cases rather than refusing to send the message.

@axiak 