### PR TITLE
Throw an exception if the MessageContent could not be read

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -339,6 +339,11 @@ public class SmtpSession {
       Iterator<ByteBuf> chunkIterator = content.getContentChunkIterator(channel.alloc());
 
       ByteBuf firstChunk = chunkIterator.next();
+      if (firstChunk == null) {
+        throw new IllegalArgumentException("The MessageContent was empty; size is " +
+            (content.size().isPresent() ? Integer.toString(content.size().getAsInt()) : "not present"));
+      }
+
       objects.add(getBdatRequestWithData(firstChunk, !chunkIterator.hasNext()));
 
       return beginSequence(sequenceInterceptor, objects.size(), objects.toArray())


### PR DESCRIPTION
We've seen some cases where we get a NullPointerException in `getBdatRequestWithData` suggesting `firstChunk` is null, which will happen if there is no readable content. 