### PR TITLE
Ignore SIZE 0 in the EHLO response

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/EhloResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/EhloResponse.java
@@ -90,7 +90,11 @@ public class EhloResponse {
 
   private void parseSize(List<String> parts) {
     if (parts.size() > 1) {
-      maxMessageSize = Optional.ofNullable(Longs.tryParse(parts.get(1)));
+      Optional<Long> maybeSize = Optional.ofNullable(Longs.tryParse(parts.get(1)));
+
+      if (maybeSize.isPresent() && maybeSize.get() > 0) {
+        maxMessageSize = maybeSize;
+      }
     }
   }
 

--- a/src/main/java/com/hubspot/smtp/client/SmtpSession.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSession.java
@@ -89,7 +89,6 @@ public class SmtpSession {
   private static final String AUTH_LOGIN_MECHANISM = "LOGIN";
   private static final String AUTH_XOAUTH2_MECHANISM = "XOAUTH2";
   private static final String CRLF = "\r\n";
-  private static final long VALID_MAX_MESSAGE_SIZE_THRESHOLD = 1_024L;
 
   private final Channel channel;
   private final ResponseHandler responseHandler;
@@ -693,7 +692,7 @@ public class SmtpSession {
     }
 
     long maximumSize = ehloResponse.getMaxMessageSize().get();
-    if (maximumSize >= VALID_MAX_MESSAGE_SIZE_THRESHOLD && maximumSize < size.getAsInt()) {
+    if (maximumSize < size.getAsInt()) {
       throw new MessageTooLargeException(config.getConnectionId(), maximumSize);
     }
   }

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -110,6 +110,13 @@ public class EhloResponseTest {
     assertThat(response.getMaxMessageSize()).isEmpty();
   }
 
+  @Test
+  public void itIgnoresASizeOfZero() {
+    EhloResponse response = parse("smtp.example.com Hello client.example.com", "SIZE 0");
+    assertThat(response.isSupported(Extension.SIZE)).isTrue();
+    assertThat(response.getMaxMessageSize()).isEmpty();
+  }
+
   private EhloResponse parse(CharSequence... lines) {
     return EhloResponse.parse("", Lists.newArrayList(lines));
   }

--- a/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
+++ b/src/test/java/com/hubspot/smtp/client/SmtpSessionTest.java
@@ -178,15 +178,6 @@ public class SmtpSessionTest {
   }
 
   @Test
-  public void itIgnoresMaxMessageSizeIfItIsLowerThan1k() {
-    session.parseEhloResponse(EHLO_DOMAIN, Lists.newArrayList("SIZE 1023"));
-
-    MessageContent largeMessage = MessageContent.of(ByteSource.wrap(new byte[1024]));
-
-    session.send(largeMessage);
-  }
-
-  @Test
   public void itWrapsTheResponse() throws ExecutionException, InterruptedException {
     CompletableFuture<SmtpClientResponse> future = session.send(SMTP_REQUEST);
 


### PR DESCRIPTION
The SIZE spec specifically calls out size '0' as indicating that no size limits are in effect. We haven't seen any other bad values in the wild, so replacing the validity threshold with this is better.

@axiak 