### PR TITLE
Log the response we're waiting for in KeepAliveHandler

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/KeepAliveHandler.java
@@ -2,6 +2,7 @@ package com.hubspot.smtp.client;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +41,12 @@ class KeepAliveHandler extends IdleStateHandler {
 
     if (expectingNoopResponse) {
       LOG.warn("[{}] Did not receive a response to our last NOOP, will not send another", connectionId);
-    } else if (responseHandler.isResponsePending()) {
-      LOG.warn("[{}] Waiting for a response, will not send a NOOP to keep the connection alive", connectionId);
+      return;
+    }
+
+    Optional<String> debugString = responseHandler.getPendingResponseDebugString();
+    if (debugString.isPresent()) {
+      LOG.warn("[{}] Waiting for a response to [{}], will not send a NOOP to keep the connection alive", connectionId, debugString.get());
     } else {
       LOG.debug("[{}] Sending NOOP", connectionId);
       ctx.channel().writeAndFlush(new DefaultSmtpRequest(SmtpCommand.NOOP));

--- a/src/main/java/com/hubspot/smtp/client/ResponseHandler.java
+++ b/src/main/java/com/hubspot/smtp/client/ResponseHandler.java
@@ -72,8 +72,8 @@ class ResponseHandler extends SimpleChannelInboundHandler<SmtpResponse> {
     });
   }
 
-  boolean isResponsePending() {
-    return responseCollector.get() != null;
+  Optional<String> getPendingResponseDebugString() {
+    return Optional.ofNullable(this.responseCollector.get()).map(ResponseCollector::getDebugString);
   }
 
   @Override

--- a/src/test/java/com/hubspot/smtp/client/KeepAliveHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/KeepAliveHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,6 +36,7 @@ public class KeepAliveHandlerTest {
     handler = new TestHandler(responseHandler, CONNECTION_ID, Duration.ofSeconds(30));
 
     when(context.channel()).thenReturn(channel);
+    when(responseHandler.getPendingResponseDebugString()).thenReturn(Optional.empty());
   }
 
   @Test
@@ -54,7 +56,7 @@ public class KeepAliveHandlerTest {
 
   @Test
   public void itDoesNotSendANoopIfACommandResponseIsPending() {
-    when(responseHandler.isResponsePending()).thenReturn(true);
+    when(responseHandler.getPendingResponseDebugString()).thenReturn(Optional.of("test"));
 
     handler.triggerIdle();
 

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -155,11 +155,11 @@ public class ResponseHandlerTest {
 
   @Test
   public void itCanTellWhenAResponseIsPending() {
-    assertThat(responseHandler.isResponsePending()).isFalse();
+    assertThat(responseHandler.getPendingResponseDebugString()).isEmpty();
 
     responseHandler.createResponseFuture(1, DEBUG_STRING);
 
-    assertThat(responseHandler.isResponsePending()).isTrue();
+    assertThat(responseHandler.getPendingResponseDebugString()).contains(DEBUG_STRING.get());
   }
 
   @Test


### PR DESCRIPTION
If this message is logged, it's likely because something has timed out; understanding what will help to troubleshoot.

@axiak 