### PR TITLE
Close the connection if the remote server doesn't respond

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -42,6 +42,11 @@ abstract class AbstractSmtpSessionConfig {
   public abstract Optional<Duration> getReadTimeout();
 
   /**
+   * The time to wait for the initial response from the server.
+   */
+  public abstract Optional<Duration> getInitialResponseReadTimeout();
+
+  /**
    * A {@link SendInterceptor} that can intercept commands and data before
    * they are sent to the server.
    *

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -175,10 +175,21 @@ public class ResponseHandlerTest {
   }
 
   @Test
-  public void itCompletesExceptionallyIfTheResponseTimeoutIsExceeded() throws Exception {
+  public void itCompletesExceptionallyIfTheDefaultResponseTimeoutIsExceeded() throws Exception {
     ResponseHandler impatientHandler = new ResponseHandler(CONNECTION_ID, Optional.of(Duration.ofMillis(200)), Optional.empty());
 
     CompletableFuture<List<SmtpResponse>> responseFuture = impatientHandler.createResponseFuture(1, DEBUG_STRING);
+    assertThat(responseFuture.isCompletedExceptionally()).isFalse();
+
+    Thread.sleep(400);
+    assertThat(responseFuture.isCompletedExceptionally()).isTrue();
+  }
+
+  @Test
+  public void itCompletesExceptionallyIfTheResponseTimeoutIsExceeded() throws Exception {
+    ResponseHandler impatientHandler = new ResponseHandler(CONNECTION_ID, Optional.of(Duration.ofDays(365)), Optional.empty());
+
+    CompletableFuture<List<SmtpResponse>> responseFuture = impatientHandler.createResponseFuture(1, Optional.of(Duration.ofMillis(200)), DEBUG_STRING);
     assertThat(responseFuture.isCompletedExceptionally()).isFalse();
 
     Thread.sleep(400);


### PR DESCRIPTION
If we successfully connect via TCP, but the server doesn't respond,
we should time out and ensure the connection is closed. Previously,
the connect future would complete exceptionally but the channel
would remain open, along with its KeepAliveHandler if configured.

We use a separate timeout here because clients might reasonably
expect servers to respond quicker to the initial connection
compared to, e.g., a DATA command.