### PR TITLE
Support SMTPUTF8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-codec</artifactId>
+        <version>${netty41.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>${netty41.version}</version>
       </dependency>
@@ -109,6 +114,10 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/src/main/java/com/hubspot/smtp/client/DotCrlfBuffer.java
+++ b/src/main/java/com/hubspot/smtp/client/DotCrlfBuffer.java
@@ -1,0 +1,15 @@
+package com.hubspot.smtp.client;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+class DotCrlfBuffer {
+  private static final byte[] DOT_CRLF = {'.', '\r', '\n'};
+
+  private static final ByteBuf INSTANCE = Unpooled.unreleasableBuffer(
+      Unpooled.directBuffer(3).writeBytes(DOT_CRLF));
+
+  static ByteBuf get() {
+    return INSTANCE.duplicate();
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/Extension.java
+++ b/src/main/java/com/hubspot/smtp/client/Extension.java
@@ -19,7 +19,8 @@ public enum Extension {
   SIZE("size"),
   STARTTLS("starttls"),
   XCLIENT("xclient"),
-  XFORWARD("xforward");
+  XFORWARD("xforward"),
+  SMTPUTF8("smtputf8");
 
   private final String lowerCaseName;
 

--- a/src/main/java/com/hubspot/smtp/client/Initializer.java
+++ b/src/main/java/com/hubspot/smtp/client/Initializer.java
@@ -6,8 +6,6 @@ import java.util.List;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.smtp.SmtpRequestEncoder;
-import io.netty.handler.codec.smtp.SmtpResponseDecoder;
 import io.netty.handler.stream.ChunkedWriteHandler;
 
 class Initializer extends ChannelInitializer<SocketChannel> {
@@ -29,8 +27,8 @@ class Initializer extends ChannelInitializer<SocketChannel> {
   private ChannelHandler[] getChannelHandlers() {
     List<ChannelHandler> handlers = new ArrayList<>();
 
-    handlers.add(new SmtpRequestEncoder());
-    handlers.add(new SmtpResponseDecoder(MAX_LINE_LENGTH));
+    handlers.add(new Utf8SmtpRequestEncoder());
+    handlers.add(new Utf8SmtpResponseDecoder(MAX_LINE_LENGTH));
     handlers.add(new ChunkedWriteHandler());
 
     config.getKeepAliveTimeout().ifPresent(timeout -> handlers.add(new KeepAliveHandler(responseHandler, config.getConnectionId(), timeout)));

--- a/src/main/java/com/hubspot/smtp/client/Utf8SmtpRequestEncoder.java
+++ b/src/main/java/com/hubspot/smtp/client/Utf8SmtpRequestEncoder.java
@@ -1,0 +1,77 @@
+package com.hubspot.smtp.client;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.RandomAccess;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.smtp.SmtpRequest;
+
+// Based very closely on SmtpRequestEncoder, but supports utf8 parameters
+// and doesn't require the LastSmtpContent because we always send a single content object
+public final class Utf8SmtpRequestEncoder extends MessageToMessageEncoder<Object> {
+  private static final byte[] CRLF = {'\r', '\n'};
+  private static final byte SP = ' ';
+
+  @Override
+  public boolean acceptOutboundMessage(Object msg) throws Exception {
+    return msg instanceof SmtpRequest;
+  }
+
+  @Override
+  protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+    if (!(msg instanceof SmtpRequest)) {
+      return;
+    }
+
+    boolean release = true;
+    final ByteBuf buffer = ctx.alloc().buffer();
+
+    try {
+      final SmtpRequest req = (SmtpRequest) msg;
+
+      ByteBufUtil.writeAscii(buffer, req.command().name());
+      writeParameters(req.parameters(), buffer);
+      buffer.writeBytes(CRLF);
+
+      out.add(buffer);
+      release = false;
+    } finally {
+      if (release) {
+        buffer.release();
+      }
+    }
+  }
+
+  private static void writeParameters(List<CharSequence> parameters, ByteBuf out) {
+    if (parameters.isEmpty()) {
+      return;
+    }
+
+    out.writeByte(SP);
+
+    if (parameters instanceof RandomAccess) {
+      int sizeMinusOne = parameters.size() - 1;
+      for (int i = 0; i < sizeMinusOne; i++) {
+        ByteBufUtil.writeUtf8(out, parameters.get(i));
+        out.writeByte(SP);
+      }
+
+      ByteBufUtil.writeUtf8(out, parameters.get(sizeMinusOne));
+
+    } else {
+      Iterator<CharSequence> params = parameters.iterator();
+      while (true) {
+        ByteBufUtil.writeUtf8(out, params.next());
+        if (params.hasNext()) {
+          out.writeByte(SP);
+        } else {
+          break;
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/hubspot/smtp/client/Utf8SmtpResponseDecoder.java
+++ b/src/main/java/com/hubspot/smtp/client/Utf8SmtpResponseDecoder.java
@@ -1,0 +1,97 @@
+package com.hubspot.smtp.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.smtp.DefaultSmtpResponse;
+import io.netty.handler.codec.smtp.SmtpResponse;
+import io.netty.util.CharsetUtil;
+
+// A copy of Netty's SmtpResponseDecoder but parses responses using UTF8
+public final class Utf8SmtpResponseDecoder extends LineBasedFrameDecoder {
+
+  private List<CharSequence> details;
+
+  /**
+   * Creates a new instance that enforces the given {@code maxLineLength}.
+   */
+  public Utf8SmtpResponseDecoder(int maxLineLength) {
+    super(maxLineLength);
+  }
+
+  @Override
+  protected SmtpResponse decode(ChannelHandlerContext ctx, ByteBuf buffer) throws Exception {
+    ByteBuf frame = (ByteBuf) super.decode(ctx, buffer);
+    if (frame == null) {
+      // No full line received yet.
+      return null;
+    }
+    try {
+      final int readable = frame.readableBytes();
+      final int readerIndex = frame.readerIndex();
+      if (readable < 3) {
+        throw newDecoderException(buffer, readerIndex, readable);
+      }
+      final int code = parseCode(frame);
+      final int separator = frame.readByte();
+      final CharSequence detail = frame.isReadable() ? frame.toString(CharsetUtil.UTF_8) : null;
+
+      List<CharSequence> details = this.details;
+
+      switch (separator) {
+        case ' ':
+          // Marks the end of a response.
+          this.details = null;
+          if (details != null) {
+            if (detail != null) {
+              details.add(detail);
+            }
+          } else {
+            details = Collections.singletonList(detail);
+          }
+          return new DefaultSmtpResponse(code, details.toArray(new CharSequence[0]));
+        case '-':
+          // Multi-line response.
+          if (detail != null) {
+            if (details == null) {
+              // Using initial capacity as it is very unlikely that we will receive a multi-line response
+              // with more then 3 lines.
+              this.details = details = new ArrayList<>(4);
+            }
+            details.add(detail);
+          }
+          break;
+        default:
+          throw newDecoderException(buffer, readerIndex, readable);
+      }
+    } finally {
+      frame.release();
+    }
+    return null;
+  }
+
+  private static DecoderException newDecoderException(ByteBuf buffer, int readerIndex, int readable) {
+    return new DecoderException(
+        "Received invalid line: '" + buffer.toString(readerIndex, readable, CharsetUtil.UTF_8) + '\'');
+  }
+
+  /**
+   * Parses the io.netty.handler.codec.smtp code without any allocation, which is three digits.
+   */
+  private static int parseCode(ByteBuf buffer) {
+    final int first = parseNumber(buffer.readByte()) * 100;
+    final int second = parseNumber(buffer.readByte()) * 10;
+    final int third = parseNumber(buffer.readByte());
+    return first + second + third;
+  }
+
+  private static int parseNumber(byte b) {
+    return Character.digit((char) b, 10);
+  }
+}
+

--- a/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
+++ b/src/test/java/com/hubspot/smtp/client/EhloResponseTest.java
@@ -23,11 +23,13 @@ public class EhloResponseTest {
         "AUTH PLAIN LOGIN",
         "8BITMIME",
         "STARTTLS",
-        "SIZE");
+        "SIZE",
+        "SMTPUTF8");
 
     assertThat(response.isSupported(Extension.EIGHT_BIT_MIME)).isTrue();
     assertThat(response.isSupported(Extension.STARTTLS)).isTrue();
     assertThat(response.isSupported(Extension.SIZE)).isTrue();
+    assertThat(response.isSupported(Extension.SMTPUTF8)).isTrue();
 
     assertThat(response.isSupported(Extension.PIPELINING)).isFalse();
 


### PR DESCRIPTION
Adds support for SMTPUTF8 ([rfc](https://tools.ietf.org/html/rfc6531)).

If supported is detected in the EHLO response and the sender or recipients' addresses contain unicode characters, the SMTPUTF8 parameter is sent with the MAIL command.

Netty's SmtpRequestEncoder and SmtpResponseDecoder render and parse parameters as ASCII, so these were copied into this project and changed slightly. 

@axiak @kevinwbaker