### PR TITLE
Include response details when we handle an exception

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/ResponseCollector.java
+++ b/src/main/java/com/hubspot/smtp/client/ResponseCollector.java
@@ -51,6 +51,6 @@ class ResponseCollector {
   }
 
   void completeExceptionally(Throwable cause) {
-    future.completeExceptionally(cause);
+    future.completeExceptionally(new ResponseException(cause, getDebugString(), responses));
   }
 }

--- a/src/main/java/com/hubspot/smtp/client/ResponseException.java
+++ b/src/main/java/com/hubspot/smtp/client/ResponseException.java
@@ -1,0 +1,23 @@
+package com.hubspot.smtp.client;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.hubspot.smtp.utils.SmtpResponses;
+
+import io.netty.handler.codec.smtp.SmtpResponse;
+
+public class ResponseException extends RuntimeException {
+
+  public ResponseException(Throwable cause, String debugString, List<SmtpResponse> responses) {
+    super(createMessage(debugString, responses), cause);
+  }
+
+  private static String createMessage(String debugString, List<SmtpResponse> responses) {
+    String responsesSoFar = responses.isEmpty() ? "<none>" :
+        String.join(",", responses.stream().map(SmtpResponses::toString).collect(Collectors.toList()));
+
+    return String.format("Received an exception while waiting for a response to [%s]; responses so far: %s",
+        debugString, responsesSoFar);
+  }
+}

--- a/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/ResponseHandlerTest.java
@@ -2,13 +2,13 @@ package com.hubspot.smtp.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.*;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -44,7 +44,11 @@ public class ResponseHandlerTest {
     responseHandler.exceptionCaught(context, testException);
 
     assertThat(f.isCompletedExceptionally()).isTrue();
-    assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class).hasCause(testException);
+
+    assertThat(catchThrowable(f::get).getCause())
+        .isInstanceOf(ResponseException.class)
+        .hasMessage("Received an exception while waiting for a response to [debug]; responses so far: <none>")
+        .hasCause(testException);
   }
 
   @Test
@@ -125,7 +129,11 @@ public class ResponseHandlerTest {
     responseHandler.exceptionCaught(context, testException);
 
     assertThat(f.isCompletedExceptionally()).isTrue();
-    assertThatThrownBy(f::get).isInstanceOf(ExecutionException.class).hasCause(testException);
+
+    assertThat(catchThrowable(f::get).getCause())
+        .isInstanceOf(ResponseException.class)
+        .hasMessage("Received an exception while waiting for a response to [debug]; responses so far: <none>")
+        .hasCause(testException);
   }
 
   @Test
@@ -169,9 +177,11 @@ public class ResponseHandlerTest {
     responseHandler.channelInactive(context);
 
     assertThat(f.isCompletedExceptionally()).isTrue();
-    assertThatThrownBy(f::get)
-        .hasCauseInstanceOf(ChannelClosedException.class)
-        .hasMessageEndingWith(CONNECTION_ID_PREFIX + "Handled channelInactive while waiting for a response to [" + DEBUG_STRING.get() + "]");
+
+    assertThat(catchThrowable(f::get).getCause())
+        .isInstanceOf(ResponseException.class)
+        .hasMessage("Received an exception while waiting for a response to [debug]; responses so far: <none>")
+        .hasCauseInstanceOf(ChannelClosedException.class);
   }
 
   @Test


### PR DESCRIPTION
If a server is using pipelining we may have already
received valid responses before a connection is closed.
To help debugging, we should include details of any
received responses when throwing an exception.

@kevinwbaker 