### PR TITLE
Simplify connect and initial response read timeouts

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
+++ b/src/main/java/com/hubspot/smtp/client/AbstractSmtpSessionConfig.java
@@ -43,8 +43,19 @@ abstract class AbstractSmtpSessionConfig {
 
   /**
    * The time to wait for the initial response from the server.
+   *
+   * @deprecated use getInitialResponseTimeout instead, which applies to the combined time of connecting and receiving the initial response
    */
+  @Deprecated
   public abstract Optional<Duration> getInitialResponseReadTimeout();
+
+  /**
+   * The time to wait for the initial response from the server. This includes the connect time.
+   */
+  @Default
+  public Duration getInitialResponseTimeout() {
+    return getInitialResponseReadTimeout().orElse(Duration.ofMinutes(1));
+  }
 
   /**
    * A {@link SendInterceptor} that can intercept commands and data before
@@ -64,8 +75,11 @@ abstract class AbstractSmtpSessionConfig {
 
   /**
    * The time to wait while connecting to a remote server.
+   *
+   * @deprecated use initialResponseTimeout instead, which applies to the combined time of connecting and receiving the initial response
    */
   @Default
+  @Deprecated
   public Duration getConnectionTimeout() {
     return Duration.ofMinutes(2);
   }

--- a/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
+++ b/src/main/java/com/hubspot/smtp/client/SmtpSessionFactory.java
@@ -3,6 +3,7 @@ package com.hubspot.smtp.client;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.slf4j.Logger;
@@ -46,13 +47,13 @@ public class SmtpSessionFactory implements Closeable  {
    */
   public CompletableFuture<SmtpClientResponse> connect(SmtpSessionConfig config) {
     ResponseHandler responseHandler = new ResponseHandler(config.getConnectionId(), config.getReadTimeout(), config.getExceptionHandler());
-    CompletableFuture<List<SmtpResponse>> initialResponseFuture = responseHandler.createResponseFuture(1, config.getInitialResponseReadTimeout(), () -> "initial response");
+    CompletableFuture<List<SmtpResponse>> initialResponseFuture = responseHandler.createResponseFuture(1, Optional.of(config.getInitialResponseTimeout()), () -> "initial response");
 
     Bootstrap bootstrap = new Bootstrap()
         .group(factoryConfig.getEventLoopGroup())
         .channel(factoryConfig.getChannelClass())
         .option(ChannelOption.ALLOCATOR, factoryConfig.getAllocator())
-        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) config.getConnectionTimeout().toMillis())
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) config.getInitialResponseTimeout().toMillis())
         .remoteAddress(config.getRemoteAddress())
         .localAddress(config.getLocalAddress().orElse(null))
         .handler(new Initializer(responseHandler, config));


### PR DESCRIPTION
When we connect to an SMTP server, we wait for two events: the initial TCP
connection completing (from the client's point of view, this is the
arrival of the SYN/ACK from the remote server) and receiving the initial
SMTP message (e.g. "220 OK").

Users of this library however, aren't able to do much with this
distinction. There's nothing productive to do until the initial response
is received, so that is the only timeout that really matters.

Futhermore, there was a bug in the previous implementation: if you set a
lower initialResponseReadTimeout than connectionTimeout, the client would
always see a failure even if the TCP connection was established.

Instead, we simplify the API by adding initialResponseTimeout.
This applies to the time from the initial SYN sent from the client to
the arrival of the initial SMTP response. This is what users of the API
likely want, and makes it impossible to misconfigure these timeouts.

@kevinwbaker