### PR TITLE
switch to CharMatcher.whitespace()

### DIFF
--- a/src/main/java/com/hubspot/smtp/client/EhloResponse.java
+++ b/src/main/java/com/hubspot/smtp/client/EhloResponse.java
@@ -20,7 +20,7 @@ import com.google.common.primitives.Longs;
 public class EhloResponse {
   static final EhloResponse EMPTY = EhloResponse.parse("", Collections.emptyList());
 
-  private static final Splitter WHITESPACE_SPLITTER = Splitter.on(CharMatcher.WHITESPACE);
+  private static final Splitter WHITESPACE_SPLITTER = Splitter.on(CharMatcher.whitespace());
 
   private final String ehloDomain;
   private final ImmutableSet<String> supportedExtensions;


### PR DESCRIPTION
`CharMatcher.WHITESPACE` should be updated to `CharMatcher.whitespace()`