### PR TITLE
upgrade netty to 4.1.110

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.9</version>
+    <version>59.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>NioSmtpClient</artifactId>

--- a/src/test/java/com/hubspot/smtp/IntegrationTest.java
+++ b/src/test/java/com/hubspot/smtp/IntegrationTest.java
@@ -7,7 +7,11 @@ import static io.netty.handler.codec.smtp.SmtpCommand.QUIT;
 import static io.netty.handler.codec.smtp.SmtpCommand.RCPT;
 import static io.netty.handler.codec.smtp.SmtpCommand.RSET;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.endsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.ByteSource;
@@ -492,6 +496,7 @@ public class IntegrationTest {
       return SslContextBuilder
         .forClient()
         .trustManager(InsecureTrustManagerFactory.INSTANCE)
+        .protocols("TLSv1.2")
         .build()
         .newEngine(PooledByteBufAllocator.DEFAULT);
     } catch (Exception e) {

--- a/src/test/java/com/hubspot/smtp/client/KeepAliveHandlerTest.java
+++ b/src/test/java/com/hubspot/smtp/client/KeepAliveHandlerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.smtp.DefaultSmtpRequest;
@@ -44,6 +45,10 @@ public class KeepAliveHandlerTest {
     handler = new TestHandler(responseHandler, CONNECTION_ID, Duration.ofSeconds(30));
 
     when(context.channel()).thenReturn(channel);
+
+    ChannelFuture writeFuture = mock(ChannelFuture.class);
+    when(context.write(any(), any())).thenReturn(writeFuture);
+
     when(responseHandler.getPendingResponseDebugString()).thenReturn(Optional.empty());
   }
 


### PR DESCRIPTION
basepom 59.10 upgrades netty from 4.1.8 to 4.1.110.

`IntegrationTest` fails with the upgrade, with the error:
```
javax.net.ssl.SSLException: Received fatal alert: internal_error
```

which was wrapping this error:
```
No supported CertificateVerify signature algorithm for RSA  key
```

I believe this is due to default protocol changing to [`TLSv1.3`](https://github.com/netty/netty/commit/b1d3aad404a39143da7a86c121d60f35c0d21108), and the effect it as on the fixture cert used in the test.
